### PR TITLE
README: --wsdl-namespace was specified twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ To generate a package, nothing as simple as this:
         --wsdl-gathermethods="start" \
         --wsdl-genericconstants=false \
         --wsdl-gentutorial=true \
-        --wsdl-namespace="My\Project" \
         --wsdl-standalone=true \
         --wsdl-addcomments="date:2015-04-22" \
         --wsdl-addcomments="author:Me" \


### PR DESCRIPTION
just a small fixup - the second occurance always overwrites the first so I think this is more correct.