### PR TITLE
Refactor

### DIFF
--- a/Command/GeneratePackageCommand.php
+++ b/Command/GeneratePackageCommand.php
@@ -57,8 +57,8 @@ class GeneratePackageCommand extends AbstractCommand
             ->addOption('wsdl-proxy-port', null, InputOption::VALUE_OPTIONAL, 'Use proxy port')
             ->addOption('wsdl-proxy-login', null, InputOption::VALUE_OPTIONAL, 'Use proxy login')
             ->addOption('wsdl-proxy-password', null, InputOption::VALUE_OPTIONAL, 'Use proxy password')
-            ->addOption('wsdl-prefix', null, InputOption::VALUE_REQUIRED, 'Prepend generated classes')
             ->addOption('wsdl-namespace', null, InputOption::VALUE_OPTIONAL, 'Package classes\' namespace')
+            ->addOption('wsdl-composername', null, InputOption::VALUE_OPTIONAL, 'Name for composer package. Defaults to namespace if not defined.')
             ->addOption('wsdl-category', null, InputOption::VALUE_OPTIONAL, 'First level directory name generation mode (start, end, cat, none)')
             ->addOption('wsdl-gathermethods', null, InputOption::VALUE_OPTIONAL, 'Gather methods based on operation name mode (start, end)')
             ->addOption('wsdl-gentutorial', null, InputOption::VALUE_OPTIONAL, 'Enable/Disable tutorial file, you should enable this option only on dev')
@@ -78,7 +78,6 @@ class GeneratePackageCommand extends AbstractCommand
         $wsdlUrl = $this->input->getOption('wsdl-urlorpath');
         $wsdlLogin = $this->input->getOption('wsdl-login');
         $wsdlPassword = $this->input->getOption('wsdl-password');
-        $packageName = $this->input->getOption('wsdl-prefix');
         $packageDestination = $this->input->getOption('wsdl-destination');
         $wsdlOptions = $this->defineWsdlOptions();
 
@@ -87,7 +86,7 @@ class GeneratePackageCommand extends AbstractCommand
         $packageGenerationOptions = $this->definePackageGenerationOptions();
 
         if ($this->canExecute()) {
-            $this->getGenerator()->generateClasses($packageName, $packageDestination);
+            $this->getGenerator()->generateClasses($packageDestination);
         } else {
             $this->writeLn("  Generation not launched, use --force to force generation");
             $this->writeLn("  Wsdl used:");
@@ -95,7 +94,6 @@ class GeneratePackageCommand extends AbstractCommand
                 'url' => $wsdlUrl,
                 'login' => $wsdlLogin,
                 'password' => $wsdlPassword,
-                'Package name' => $packageName,
                 'Package dest' => $packageDestination,
             ))));
             $this->writeLn("  Wsdl options used:");
@@ -140,6 +138,7 @@ class GeneratePackageCommand extends AbstractCommand
     {
         return array(
             'wsdl-namespace' => 'NamespacePrefix',
+            'wsdl-composername' => 'ComposerName',
             'wsdl-category' => 'Category',
             'wsdl-gathermethods' => 'GatherMethods',
             'wsdl-gentutorial' => 'GenerateTutorialFile',

--- a/ConfigurationReader/GeneratorOptions.php
+++ b/ConfigurationReader/GeneratorOptions.php
@@ -22,6 +22,7 @@ class GeneratorOptions extends AbstractYamlReader
     const ADD_COMMENTS = 'add_comments';
     const GATHER_METHODS = 'gather_methods';
     const NAMESPACE_PREFIX = 'namespace_prefix';
+    const COMPOSER_NAME = 'composer_name';
     const GENERATE_TUTORIAL_FILE = 'generate_tutorial_file';
     const GENERIC_CONSTANTS_NAME = 'generic_constants_names';
     /**
@@ -192,6 +193,24 @@ class GeneratorOptions extends AbstractYamlReader
     public function setNamespace($namespace)
     {
         return $this->setOptionValue(self::NAMESPACE_PREFIX, $namespace);
+    }
+    /**
+     * Get composer name option value
+     * @return string|bool
+     */
+    public function getComposerName()
+    {
+        return $this->getOptionValue(self::COMPOSER_NAME);
+    }
+    /**
+     * Set composer name option value
+     * @throws \InvalidArgumentException
+     * @param string $composerName
+     * @return GeneratorOptions
+     */
+    public function setComposerName($composerName)
+    {
+        return $this->setOptionValue(self::COMPOSER_NAME, $composerName);
     }
     /**
      * Get generic constants name option value

--- a/File/AbstractModelFile.php
+++ b/File/AbstractModelFile.php
@@ -119,7 +119,7 @@ abstract class AbstractModelFile extends AbstractFile
      */
     protected function definePackageAnnotations(PhpAnnotationBlock $block)
     {
-        $block->addChild(new PhpAnnotation(self::ANNOTATION_PACKAGE, $this->getGenerator()->getPackageName()));
+        $block->addChild(new PhpAnnotation(self::ANNOTATION_PACKAGE, $this->getGenerator()->getOptionNamespacePrefix()));
         if (count($this->getModel()->getDocSubPackages()) > 0) {
             $block->addChild(new PhpAnnotation(self::ANNOTATION_SUB_PACKAGE, implode(',', $this->getModel()->getDocSubPackages())));
         }
@@ -292,7 +292,7 @@ abstract class AbstractModelFile extends AbstractFile
         return $this;
     }
     /**
-     * @param Constant
+     * @param Constant $constants
      */
     abstract protected function getClassConstants(Constant $constants);
     /**
@@ -301,7 +301,7 @@ abstract class AbstractModelFile extends AbstractFile
      */
     abstract protected function getConstantAnnotationBlock(PhpConstant $constant);
     /**
-     * @param Property
+     * @param Property $properties
      */
     abstract protected function getClassProperties(Property $properties);
     /**
@@ -310,7 +310,7 @@ abstract class AbstractModelFile extends AbstractFile
      */
     abstract protected function getPropertyAnnotationBlock(PhpProperty $property);
     /**
-     * @param Method
+     * @param Method $methods
      */
     abstract protected function getClassMethods(Method $methods);
     /**
@@ -320,6 +320,7 @@ abstract class AbstractModelFile extends AbstractFile
     abstract protected function getMethodAnnotationBlock(PhpMethod $method);
     /**
      * @param PhpClass $class
+     * @return ClassMap
      */
     protected function defineStringMethod(PhpClass $class)
     {

--- a/File/ClassMap.php
+++ b/File/ClassMap.php
@@ -43,6 +43,7 @@ class ClassMap extends AbstractModelFile
     }
     /**
      * @param MethodContainer $methods
+     * @return ClassMap
      */
     protected function getClassMethods(MethodContainer $methods)
     {
@@ -71,7 +72,7 @@ class ClassMap extends AbstractModelFile
     {
         return new PhpAnnotationBlock(array(
             'Class which returns the class map definition',
-            new PhpAnnotation(self::ANNOTATION_PACKAGE, $this->getGenerator()->getPackageName()),
+            new PhpAnnotation(self::ANNOTATION_PACKAGE, $this->getGenerator()->getOptionNamespacePrefix()),
         ));
     }
     /**

--- a/Generator/Generator.php
+++ b/Generator/Generator.php
@@ -260,7 +260,7 @@ class Generator extends \SoapClient
      */
     private function generateStructsClasses($rootDirectory, $rootDirectoryRights)
     {
-        foreach ($this->getStructs() as $structName => $struct) {
+        foreach ($this->getStructs() as $struct) {
             if (!$struct->getIsStruct()) {
                 continue;
             }

--- a/Generator/Generator.php
+++ b/Generator/Generator.php
@@ -211,12 +211,11 @@ class Generator extends \SoapClient
      * @param bool $createRootDirectory create root directory if not exist
      * @return bool true|false depending on the well creation fot the root directory
      */
-    public function generateClasses($packageName, $rootDirectory, $rootDirectoryRights = 0775, $createRootDirectory = true)
+    public function generateClasses($rootDirectory, $rootDirectoryRights = 0775, $createRootDirectory = true)
     {
         $wsdl = $this->getWsdl(0);
         $wsdlLocation = $wsdl instanceof Wsdl ? $wsdl->getName() : '';
         if (!empty($wsdlLocation)) {
-            $this->setPackageName($packageName);
             $rootDirectory = $rootDirectory . (substr($rootDirectory, -1) != '/' ? '/' : '');
             /**
              * Root directory
@@ -349,7 +348,7 @@ class Generator extends \SoapClient
                 'command' => 'init',
                 '--verbose' => true,
                 '--no-interaction' => true,
-                '--name' => sprintf('wsdltophp/generated-%s', strtolower(self::getPackageName())),
+                '--name' => $this->getComposerName(),
                 '--description' => sprintf('Package generated from %s using wsdltophp/packagegenerator', $this->getWsdl(0)->getName()),
                 '--require' => array(
                     'php:>=5.3.3',
@@ -477,13 +476,30 @@ class Generator extends \SoapClient
         return $this->options->getNamespace();
     }
     /**
-     * Sets the optionGenerateTutorialFile value
+     * Sets the optionNamespacePrefix value
      * @param bool
      * @return GeneratorOptions
      */
     public function setOptionNamespacePrefix($namespace)
     {
         return $this->options->setNamespace($namespace);
+    }
+    /**
+     * Gets the optionComposerName value
+     * @return string
+     */
+    public function getOptionComposerName()
+    {
+        return $this->options->getComposerName();
+    }
+    /**
+     * Sets the optionComposerName value
+     * @param string
+     * @return GeneratorOptions
+     */
+    public function setOptionComposerName($composerName)
+    {
+        return $this->options->setComposerName($composerName);
     }
     /**
      * Gets the optionAddComments value
@@ -520,25 +536,6 @@ class Generator extends \SoapClient
         return $this->options->setStandalone($standalone);
     }
     /**
-     * Gets the package name
-     * @param bool $ucFirst ucfirst package name or not
-     * @return string
-     */
-    public function getPackageName($ucFirst = true)
-    {
-        return $ucFirst ? ucfirst($this->packageName) : $this->packageName;
-    }
-    /**
-     * Sets the package name
-     * @param string $packageName
-     * @return Generator
-     */
-    public function setPackageName($packageName)
-    {
-        $this->packageName = $packageName;
-        return $this;
-    }
-    /**
      * Gets the WSDLs
      * @return WsdlContainer
      */
@@ -568,6 +565,7 @@ class Generator extends \SoapClient
     /**
      * Adds Wsdl location
      * @param string $wsdlLocation
+     * @return Generator
      */
     public function addWsdl($wsdlLocation)
     {
@@ -743,5 +741,23 @@ class Generator extends \SoapClient
     public function __toString()
     {
         return __CLASS__;
+    }
+
+    /**
+     * @return string
+     */
+    private function getComposerName()
+    {
+        $composerName = $this->options->getComposerName();
+        if ($composerName) {
+            return $composerName;
+        }
+
+        $composerName = str_replace('\\', '/', strtolower($this->getOptionNamespacePrefix()));
+        if (strpos($composerName, '/') !== false) {
+            return $composerName;
+        }
+
+        return $composerName . "/" . $composerName;
     }
 }

--- a/Generator/Generator.php
+++ b/Generator/Generator.php
@@ -109,7 +109,7 @@ class Generator extends \SoapClient
      * @param string $password password to get access to WSDL
      * @param array $wsdlOptions options to get access to WSDL
      */
-    public function __construct($pathToWsdl, $login = false, $password = false, array $wsdlOptions = array())
+    public function __construct($pathToWsdl, $login = '', $password = '', array $wsdlOptions = array())
     {
         $this
             ->initSoapClient($pathToWsdl, $login, $password, $wsdlOptions)
@@ -126,7 +126,7 @@ class Generator extends \SoapClient
      * @throws \InvalidArgumentException
      * @return Generator
      */
-    protected function initSoapClient($pathToWsdl, $login = false, $password = false, array $wsdlOptions = array())
+    protected function initSoapClient($pathToWsdl, $login = '', $password = '', array $wsdlOptions = array())
     {
         $pathToWsdl = trim($pathToWsdl);
         /**

--- a/Model/AbstractModel.php
+++ b/Model/AbstractModel.php
@@ -340,7 +340,7 @@ abstract class AbstractModel
      */
     public function getPackagedName($namespaced = false)
     {
-        return ($namespaced ? sprintf('\%s\\', $this->getNamespace()) : '') . $this->getGenerator()->getPackageName() . ucfirst(self::uniqueName($this->getCleanName(), $this->getContextualPart()));
+        return ($namespaced ? sprintf('\%s\\', $this->getNamespace()) : '') . ucfirst(self::uniqueName($this->getCleanName(), $this->getContextualPart()));
     }
     /**
      * Allows to define the contextual part of the class name for the package

--- a/Model/AbstractModel.php
+++ b/Model/AbstractModel.php
@@ -92,7 +92,7 @@ abstract class AbstractModel
             if ($model->getIsStruct()) {
                 $extends = $model->getPackagedName();
             }
-        } elseif (class_exists($this->getInheritance()) && stripos($this->getInheritance(), $this->getGenerator()->getPackageName()) === 0) {
+        } elseif (class_exists($this->getInheritance()) && stripos($this->getInheritance(), $this->getGenerator()->getOptionNamespacePrefix()) === 0) {
             $extends = $this->getInheritance();
         }
         if (empty($extends)) {
@@ -112,6 +112,7 @@ abstract class AbstractModel
      * Sets the name of the class the current class inherits from
      * @uses AbstractModel::updateModels()
      * @param string
+     * @return string
      */
     public function setInheritance($inheritance = '')
     {
@@ -366,9 +367,8 @@ abstract class AbstractModel
     {
         $namespace = $this->getGenerator()->getOptionNamespacePrefix();
         $directory = $this->getGenerator()->getDirectory($this);
-        $packageName = $this->getGenerator()->getPackageName();
         $namespaceEnding = implode('\\', explode('/', substr($directory, 0, -1)));
-        return sprintf(empty($namespace) ? '%1$s%4$s%3$s' : '%2$s\\%1$s%4$s%3$s', $packageName, $namespace, $namespaceEnding, empty($namespaceEnding) ? '' : '\\');
+        return sprintf('%1$s%3$s%2$s', $namespace, $namespaceEnding, empty($namespaceEnding) ? '' : '\\');
     }
     /**
      * Returns the sub package name which the model belongs to

--- a/Model/Service.php
+++ b/Model/Service.php
@@ -34,7 +34,7 @@ class Service extends AbstractModel
      */
     public function getContextualPart()
     {
-        return 'ServiceType';
+        return 'Service';
     }
     /**
      * Returns the sub package name which the model belongs to

--- a/Model/Struct.php
+++ b/Model/Struct.php
@@ -12,11 +12,11 @@ use WsdlToPhp\PackageGenerator\Generator\Generator;
 class Struct extends AbstractModel
 {
     const
-        CONTEXTUAL_PART_STRUCT = 'StructType',
+        CONTEXTUAL_PART_STRUCT = 'Struct',
         DOC_SUB_PACKAGE_STRUCTS = 'Structs',
-        CONTEXTUAL_PART_ENUMERATION = 'EnumType',
+        CONTEXTUAL_PART_ENUMERATION = 'Enum',
         DOC_SUB_PACKAGE_ENUMERATIONS = 'Enumerations',
-        CONTEXTUAL_PART_ARRAY = 'ArrayType',
+        CONTEXTUAL_PART_ARRAY = 'ArrayOf',
         DOC_SUB_PACKAGE_ARRAYS = 'Arrays';
     /**
      * Attributes of the struct

--- a/Model/Struct.php
+++ b/Model/Struct.php
@@ -328,4 +328,23 @@ class Struct extends AbstractModel
     {
         return 'Struct';
     }
+    /**
+     * Returns a valid clean name for PHP
+     * @uses AbstractModel::getName()
+     * @uses AbstractModel::cleanString()
+     * @param bool $keepMultipleUnderscores optional, allows to keep the multiple consecutive underscores
+     * @return string
+     */
+    public function getCleanName($keepMultipleUnderscores = true)
+    {
+        $clean = self::cleanString($this->getName(), $keepMultipleUnderscores);
+        $context = $this->getContextualPart();
+        if (!$this->isArray()) {
+            return $clean . $context;
+        }
+        if (stripos($clean, $context) === false) {
+            return $context . $clean;
+        }
+        return $clean;
+    }
 }

--- a/Resources/config/generator_options.yml
+++ b/Resources/config/generator_options.yml
@@ -19,6 +19,9 @@ add_comments:
 namespace_prefix:
     default: ''
     values: ''
+composer_name:
+    default: ''
+    values: ''
 standalone:
     default: true
     values: [ true, false ]


### PR DESCRIPTION
PR includes the following changes:

- Remove prefix option
- Add composer-name option

Classes no longer will be prepended with the prefix.
Prefix no longer is used as packagename. Namespace should be used.
Composer name option added, to override using namespace as composername

Also includes some minor docblock fixes.

One more thing i'd like to change, rename the options, they now all start with --wsdl, while not all options relate to the wsdl itself.
Only these are wsdl related: https://github.com/wsdltophp/PackageGenerator/blob/develop/Command/GeneratePackageCommand.php#L52-L59

The other options should drop the --wsdl in their names imo

I would also prefer generated classes to be put into a src folder and have composer.json etc outside of that (probably only when generating a standalone)

EDIT: forgot to include one big change, since prefix is dropped, classnames are named differently now