### PR TITLE
Issue 63: base64Binary as string type.

### DIFF
--- a/src/resources/config/xsd_types.yml
+++ b/src/resources/config/xsd_types.yml
@@ -4,6 +4,7 @@ xsd_types:
     anonymous: "string"
     anyType: "mixed"
     anyURI: "string"
+    base64Binary: "string"
     bool: "bool"
     boolean: "bool"
     byte: "string"

--- a/tests/ConfigurationReader/XsdTypesTest.php
+++ b/tests/ConfigurationReader/XsdTypesTest.php
@@ -70,4 +70,14 @@ class XsdTypesTest extends TestCase
     {
         $this->assertSame('string', self::instance()->phpType('anonymous159'));
     }
+
+    public function testBase64BinaryXsd()
+    {
+      $this->assertTrue(self::instance()->isXsd('base64Binary'));
+    }
+
+  public function testBase64BinaryPhpType()
+  {
+    $this->assertSame('string', self::instance()->phpType('base64Binary'));
+  }
 }

--- a/tests/resources/xsd_types.yml
+++ b/tests/resources/xsd_types.yml
@@ -3,8 +3,9 @@
 xsd_types:
     int: "int"
     UID: "string"
-    byte: "string"
+    base64Binary: "string"
     bool: "bool"
+    byte: "string"
     date: "string"
     time: "string"
     long: "int"


### PR DESCRIPTION
WsdlToPhp\PackageGenerator\Tests\File\StructTest::testWriteBingSearchStructSearchRequest fails, but it fails on develop:HEAD as well so that's not related to this change.
