### PR TITLE
Fix escaping of ' and \ in pattern rule

### DIFF
--- a/src/File/Validation/PatternRule.php
+++ b/src/File/Validation/PatternRule.php
@@ -13,9 +13,11 @@ class PatternRule extends AbstractRule
      */
     public function applyRule($parameterName, $value, $itemType = false)
     {
+        $escapedPattern = addcslashes($value, '\'\\');
+
         $this->getMethod()
             ->addChild('// validation for constraint: pattern')
-            ->addChild(sprintf('if (is_scalar($%1$s) && !preg_match(\'/%2$s/\', $%1$s)) {', $parameterName, $value))
+            ->addChild(sprintf('if (is_scalar($%1$s) && !preg_match(\'/%2$s/\', $%1$s)) {', $parameterName, $escapedPattern))
             ->addChild($this->getMethod()->getIndentedString(sprintf('throw new \InvalidArgumentException(sprintf(\'Invalid value, please provide a scalar value that matches "%s", "%%s" given\', var_export($%s, true)), __LINE__);', str_replace("'", "\'", $value), $parameterName), 1))
             ->addChild('}');
         return $this;

--- a/tests/File/Validation/PatternRuleTest.php
+++ b/tests/File/Validation/PatternRuleTest.php
@@ -9,39 +9,55 @@ class PatternRuleTest extends RuleTest
      */
     public function testApplyRuleWithBool()
     {
-        $funtionName = parent::createRuleFunction('WsdlToPhp\PackageGenerator\File\Validation\PatternRule', '\d+');
-        $this->assertTrue(call_user_func($funtionName, true));
+        $functionName = parent::createRuleFunction('WsdlToPhp\PackageGenerator\File\Validation\PatternRule', '\d+');
+        $this->assertTrue(call_user_func($functionName, true));
     }
     /**
      * @expectedException \InvalidArgumentException
      */
     public function testApplyRuleWithString()
     {
-        $funtionName = parent::createRuleFunction('WsdlToPhp\PackageGenerator\File\Validation\PatternRule', '\d+');
-        $this->assertTrue(call_user_func($funtionName, 'foo'));
+        $functionName = parent::createRuleFunction('WsdlToPhp\PackageGenerator\File\Validation\PatternRule', '\d+');
+        $this->assertTrue(call_user_func($functionName, 'foo'));
     }
     /**
      *
      */
     public function testApplyRuleWithInteger()
     {
-        $funtionName = parent::createRuleFunction('WsdlToPhp\PackageGenerator\File\Validation\PatternRule', '\d+');
-        $this->assertTrue(call_user_func($funtionName, 1));
+        $functionName = parent::createRuleFunction('WsdlToPhp\PackageGenerator\File\Validation\PatternRule', '\d+');
+        $this->assertTrue(call_user_func($functionName, 1));
     }
     /**
      * @expectedException \InvalidArgumentException
      */
     public function testApplyRuleWithInvalidDate()
     {
-        $funtionName = parent::createRuleFunction('WsdlToPhp\PackageGenerator\File\Validation\PatternRule', '\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}');
-        $this->assertTrue(call_user_func($funtionName, '2017-04-04T01:00:00'));
+        $functionName = parent::createRuleFunction('WsdlToPhp\PackageGenerator\File\Validation\PatternRule', '\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}');
+        $this->assertTrue(call_user_func($functionName, '2017-04-04T01:00:00'));
     }
     /**
      *
      */
     public function testApplyRuleWithValidDate()
     {
-        $funtionName = parent::createRuleFunction('WsdlToPhp\PackageGenerator\File\Validation\PatternRule', '\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}');
-        $this->assertTrue(call_user_func($funtionName, '2017-04-04 01:00:00'));
+        $functionName = parent::createRuleFunction('WsdlToPhp\PackageGenerator\File\Validation\PatternRule', '\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}');
+        $this->assertTrue(call_user_func($functionName, '2017-04-04 01:00:00'));
+    }
+    /**
+     *
+     */
+    public function testApplyRuleWithQuote()
+    {
+        $functionName = parent::createRuleFunction('WsdlToPhp\PackageGenerator\File\Validation\PatternRule', '\'');
+        $this->assertTrue(call_user_func($functionName, '\''));
+    }
+    /**
+     *
+     */
+    public function testApplyRuleWithBackslash()
+    {
+        $functionName = parent::createRuleFunction('WsdlToPhp\PackageGenerator\File\Validation\PatternRule', '\\\\');
+        $this->assertTrue(call_user_func($functionName, '\\'));
     }
 }

--- a/tests/resources/generated/ValidPaymentCardType.php
+++ b/tests/resources/generated/ValidPaymentCardType.php
@@ -388,7 +388,7 @@ class ApiPaymentCardType extends AbstractStructBase
     public function setCardType($cardType = null)
     {
         // validation for constraint: pattern
-        if (is_scalar($cardType) && !preg_match('/[0-9A-Z]{1,3}(\.[A-Z]{3}(\.X){0,1}){0,1}/', $cardType)) {
+        if (is_scalar($cardType) && !preg_match('/[0-9A-Z]{1,3}(\\.[A-Z]{3}(\\.X){0,1}){0,1}/', $cardType)) {
             throw new \InvalidArgumentException(sprintf('Invalid value, please provide a scalar value that matches "[0-9A-Z]{1,3}(\.[A-Z]{3}(\.X){0,1}){0,1}", "%s" given', var_export($cardType, true)), __LINE__);
         }
         // validation for constraint: string

--- a/tests/resources/generated/ValidShopper.php
+++ b/tests/resources/generated/ValidShopper.php
@@ -172,7 +172,7 @@ class ApiShopper extends AbstractStructBase
     public function setEmail($email = null)
     {
         // validation for constraint: pattern
-        if (is_scalar($email) && !preg_match('/[_a-zA-Z0-9\-\+\.]+@[a-zA-Z0-9\-]+(\.[a-zA-Z0-9\-]+)*(\.[a-zA-Z]+)/', $email)) {
+        if (is_scalar($email) && !preg_match('/[_a-zA-Z0-9\\-\\+\\.]+@[a-zA-Z0-9\\-]+(\\.[a-zA-Z0-9\\-]+)*(\\.[a-zA-Z]+)/', $email)) {
             throw new \InvalidArgumentException(sprintf('Invalid value, please provide a scalar value that matches "[_a-zA-Z0-9\-\+\.]+@[a-zA-Z0-9\-]+(\.[a-zA-Z0-9\-]+)*(\.[a-zA-Z]+)", "%s" given', var_export($email, true)), __LINE__);
         }
         // validation for constraint: maxLength

--- a/tests/resources/generated/ValidTaxType.php
+++ b/tests/resources/generated/ValidTaxType.php
@@ -180,7 +180,7 @@ class ApiTaxType extends AbstractStructBase
     public function setCode($code = null)
     {
         // validation for constraint: pattern
-        if (is_scalar($code) && !preg_match('/[0-9A-Z]{1,3}(\.[A-Z]{3}(\.X){0,1}){0,1}/', $code)) {
+        if (is_scalar($code) && !preg_match('/[0-9A-Z]{1,3}(\\.[A-Z]{3}(\\.X){0,1}){0,1}/', $code)) {
             throw new \InvalidArgumentException(sprintf('Invalid value, please provide a scalar value that matches "[0-9A-Z]{1,3}(\.[A-Z]{3}(\.X){0,1}){0,1}", "%s" given', var_export($code, true)), __LINE__);
         }
         // validation for constraint: string


### PR DESCRIPTION
Adds slashes to ' and \ to escape php single quoted string.