### PR TITLE
Fix escaping of / in regex

### DIFF
--- a/src/File/Validation/PatternRule.php
+++ b/src/File/Validation/PatternRule.php
@@ -13,7 +13,7 @@ class PatternRule extends AbstractRule
      */
     public function applyRule($parameterName, $value, $itemType = false)
     {
-        $escapedPattern = addcslashes($value, '\'\\');
+        $escapedPattern = addcslashes($value, '\'\\/');
 
         $this->getMethod()
             ->addChild('// validation for constraint: pattern')

--- a/tests/File/Validation/PatternRuleTest.php
+++ b/tests/File/Validation/PatternRuleTest.php
@@ -60,4 +60,12 @@ class PatternRuleTest extends RuleTest
         $functionName = parent::createRuleFunction('WsdlToPhp\PackageGenerator\File\Validation\PatternRule', '\\\\');
         $this->assertTrue(call_user_func($functionName, '\\'));
     }
+    /**
+     *
+     */
+    public function testApplyRuleWithForwardSlash()
+    {
+        $functionName = parent::createRuleFunction('WsdlToPhp\PackageGenerator\File\Validation\PatternRule', '/');
+        $this->assertTrue(call_user_func($functionName, '/'));
+    }
 }


### PR DESCRIPTION
As '/' is used as the delimiter for the pattern regex it needs to be
escaped to prevent invalid regexes.