### PR TITLE
Add option to save schemas locally #120

### DIFF
--- a/src/Command/GeneratePackageCommand.php
+++ b/src/Command/GeneratePackageCommand.php
@@ -181,7 +181,7 @@ class GeneratePackageCommand extends AbstractCommand
         return $optionValue;
     }
     /**
-     * Utility method to return readeable array based on "key: value"
+     * Utility method to return readable array based on "key: value"
      * @param array $array
      * @return array
      */

--- a/src/Command/GeneratePackageCommand.php
+++ b/src/Command/GeneratePackageCommand.php
@@ -185,7 +185,7 @@ class GeneratePackageCommand extends AbstractCommand
      * @param array $array
      * @return array
      */
-    private function formatArrayForConsole($array)
+    protected function formatArrayForConsole($array)
     {
         array_walk($array, function (&$value, $index) {
             $value = sprintf("%s: %s", $index, json_encode($value));

--- a/src/ConfigurationReader/AbstractYamlReader.php
+++ b/src/ConfigurationReader/AbstractYamlReader.php
@@ -9,7 +9,7 @@ abstract class AbstractYamlReader
     /**
      * @var AbstractYamlReader[]
      */
-    private static $instances;
+    protected static $instances;
     /**
      * Path to file to parse
      * @var string

--- a/src/ConfigurationReader/AbstractYamlReader.php
+++ b/src/ConfigurationReader/AbstractYamlReader.php
@@ -17,7 +17,7 @@ abstract class AbstractYamlReader
     protected $filename;
     /**
      * Use singleton, instead of calling new Options(), use Options::instance()
-     * @param string options's file to parse
+     * @param string $filename options's file to parse
      */
     abstract protected function __construct($filename);
     /**

--- a/src/ConfigurationReader/GeneratorOptions.php
+++ b/src/ConfigurationReader/GeneratorOptions.php
@@ -46,6 +46,8 @@ class GeneratorOptions extends AbstractYamlReader implements \JsonSerializable
     const STRUCTS_FOLDER = 'structs_folder';
     const SUFFIX = 'suffix';
     const VALIDATION = 'validation';
+    const SCHEMAS_SAVE = 'schemas_save';
+    const SCHEMAS_FOLDER = 'schemas_folder';
     /**
      * Generator's options
      * @var array
@@ -683,6 +685,46 @@ class GeneratorOptions extends AbstractYamlReader implements \JsonSerializable
     public function setServicesFolder($servicesFolder)
     {
         return $this->setOptionValue(self::SERVICES_FOLDER, $servicesFolder);
+    }
+    /**
+     * Get schemas save option value
+     * @return bool
+     */
+    public function getSchemasSave()
+    {
+        return $this->getOptionValue(self::SCHEMAS_SAVE);
+    }
+    /**
+     * Set schemas save option value
+     * @throws \InvalidArgumentException
+     *
+     * @param bool $saveSchemas
+     *
+     * @return GeneratorOptions
+     */
+    public function setSchemasSave($saveSchemas)
+    {
+        return $this->setOptionValue(self::SCHEMAS_SAVE, $saveSchemas);
+    }
+    /**
+     * Get schemas folder option value
+     * @return bool
+     */
+    public function getSchemasFolder()
+    {
+        return $this->getOptionValue(self::SCHEMAS_FOLDER);
+    }
+    /**
+     * Set schemas folder option value
+     * @throws \InvalidArgumentException
+     *
+     * @param string $schemasFolder
+     *
+     * @return GeneratorOptions
+     */
+    public function setSchemasFolder($schemasFolder)
+    {
+        return $this->setOptionValue(self::SCHEMAS_FOLDER, $schemasFolder);
     }
     /**
      * @return string[]

--- a/src/ConfigurationReader/GeneratorOptions.php
+++ b/src/ConfigurationReader/GeneratorOptions.php
@@ -93,6 +93,8 @@ class GeneratorOptions extends AbstractYamlReader implements \JsonSerializable
      * Allows to add an option and set its value
      * @throws \InvalidArgumentException
      * @param string $optionName
+     * @param mixed $optionValue
+     * @param array $values
      * @return GeneratorOptions
      */
     public function setOptionValue($optionName, $optionValue, array $values = [])
@@ -586,7 +588,7 @@ class GeneratorOptions extends AbstractYamlReader implements \JsonSerializable
     public function setComposerSettings(array $composerSettings = [])
     {
         /**
-         * If array is type array("config.value:true","require:libray/src",)
+         * If array is type array("config.value:true","require:library/src",)
          */
         $settings = [];
         foreach ($composerSettings as $index => $value) {
@@ -697,9 +699,7 @@ class GeneratorOptions extends AbstractYamlReader implements \JsonSerializable
     /**
      * Set schemas save option value
      * @throws \InvalidArgumentException
-     *
      * @param bool $saveSchemas
-     *
      * @return GeneratorOptions
      */
     public function setSchemasSave($saveSchemas)
@@ -717,9 +717,7 @@ class GeneratorOptions extends AbstractYamlReader implements \JsonSerializable
     /**
      * Set schemas folder option value
      * @throws \InvalidArgumentException
-     *
      * @param string $schemasFolder
-     *
      * @return GeneratorOptions
      */
     public function setSchemasFolder($schemasFolder)

--- a/src/ConfigurationReader/XsdTypes.php
+++ b/src/ConfigurationReader/XsdTypes.php
@@ -9,7 +9,7 @@ class XsdTypes extends AbstractYamlReader
      */
     const MAIN_KEY = 'xsd_types';
     /**
-     * This type is returned by the \SaoapClient class when
+     * This type is returned by the \SoapClient class when
      * it does not succeed to define the type of a struct or an attribute
      * @var string
      */

--- a/src/Container/AbstractObjectContainer.php
+++ b/src/Container/AbstractObjectContainer.php
@@ -130,7 +130,7 @@ abstract class AbstractObjectContainer extends AbstractGeneratorAware implements
      * @throws \InvalidArgumentException
      * @return string
      */
-    private function getObjectKey($object)
+    protected function getObjectKey($object)
     {
         $get = sprintf('get%s', ucfirst($this->objectProperty()));
         if (!method_exists($object, $get)) {

--- a/src/File/Validation/AbstractRule.php
+++ b/src/File/Validation/AbstractRule.php
@@ -11,7 +11,7 @@ abstract class AbstractRule
     /**
      * @var Rules
      */
-    private $rules;
+    protected $rules;
     /**
      * @param Rules $rules
      */

--- a/src/File/Validation/Rules.php
+++ b/src/File/Validation/Rules.php
@@ -13,15 +13,15 @@ class Rules
     /**
      * @var StructAttribute
      */
-    private $attribute;
+    protected $attribute;
     /**
      * @var AbstractModelFile
      */
-    private $file;
+    protected $file;
     /**
      * @var PhpMethod
      */
-    private $method;
+    protected $method;
     /**
      * @param AbstractModelFile $file
      * @param PhpMethod $method

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -789,6 +789,42 @@ class Generator implements \JsonSerializable
         return $this;
     }
     /**
+     * Gets the optionSchemasSave value
+     * @return bool
+     */
+    public function getOptionSchemasSave()
+    {
+        return $this->options->getSchemasSave();
+    }
+    /**
+     * Sets the optionSchemasSave value
+     * @param bool $optionSchemasSave
+     * @return Generator
+     */
+    public function setOptionSchemasSave($optionSchemasSave)
+    {
+        $this->options->setSchemasSave($optionSchemasSave);
+        return $this;
+    }
+    /**
+     * Gets the optionSchemasFolder value
+     * @return string
+     */
+    public function getOptionSchemasFolder()
+    {
+        return $this->options->getSchemasFolder();
+    }
+    /**
+     * Sets the optionSchemasFolder value
+     * @param bool $optionSchemasFolder
+     * @return Generator
+     */
+    public function setOptionSchemasFolder($optionSchemasFolder)
+    {
+        $this->options->setSchemasFolder($optionSchemasFolder);
+        return $this;
+    }
+    /**
      * Gets the WSDL
      * @return Wsdl|null
      */

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -903,36 +903,9 @@ class Generator implements \JsonSerializable
     public function getUrlContent($url)
     {
         if (strpos($url, '://') !== false) {
-            $content = Utils::getContentFromUrl(
-                $url, 
-                $this->getOptionBasicLogin(), 
-                $this->getOptionBasicPassword(), 
-                $this->getOptionProxyHost(), 
-                $this->getOptionProxyPort(), 
-                $this->getOptionProxyLogin(), 
-                $this->getOptionProxyPassword(), 
-                $this->getSoapClient()->getSoapClientStreamContextOptions()
-            );
-            if($this->getOptions()->getSchemasSave() === true) {
-                $schemasFolder = $this->getOptions()->getSchemasFolder();
-                if(($schemasFolder == null) || empty($schemasFolder)) {
-                  $schemasFolder = 'wsdl';
-                }
-                $directory = rtrim($this->getOptions()->getDestination(), DIRECTORY_SEPARATOR)
-                    . DIRECTORY_SEPARATOR
-                    . rtrim($schemasFolder, DIRECTORY_SEPARATOR);
-                // @todo Cover all possible variants
-                if(
-                    (strpos(strtolower($url),'.wsdl') !== false) 
-                    || (strpos(strtolower($url),'.xsd') !== false) 
-                    || (strpos(strtolower($url),'.xml') !== false)
-                ) {
-                    $filename = basename($url);
-                } else {
-                    $filename = 'schema.wsdl';
-                }
-                Utils::createDirectory($directory);
-                file_put_contents($directory . DIRECTORY_SEPARATOR . $filename, $content);
+            $content = Utils::getContentFromUrl($url, $this->getOptionBasicLogin(), $this->getOptionBasicPassword(), $this->getOptionProxyHost(), $this->getOptionProxyPort(), $this->getOptionProxyLogin(), $this->getOptionProxyPassword(), $this->getSoapClient()->getSoapClientStreamContextOptions());
+            if ($this->getOptions()->getSchemasSave() === true) {
+                Utils::saveSchemas($this->getOptions()->getDestination(), $this->getOptions()->getSchemasFolder(), $url, $content);
             }
             return $content;
         } elseif (is_file($url)) {

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -20,31 +20,31 @@ class Generator implements \JsonSerializable
      * Wsdl
      * @var Wsdl
      */
-    private $wsdl;
+    protected $wsdl;
     /**
      * @var GeneratorOptions
      */
-    private $options;
+    protected $options;
     /**
      * Used parsers
      * @var GeneratorParsers
      */
-    private $parsers;
+    protected $parsers;
     /**
      * Used files
      * @var GeneratorFiles
      */
-    private $files;
+    protected $files;
     /**
      * Used containers
      * @var GeneratorContainers
      */
-    private $containers;
+    protected $containers;
     /**
      * Used SoapClient
      * @var GeneratorSoapClient
      */
-    private $soapClient;
+    protected $soapClient;
     /**
      * Constructor
      * @param GeneratorOptions $options
@@ -860,7 +860,7 @@ class Generator implements \JsonSerializable
      * @param AbstractModel $model the model for which we generate the folder
      * @return string
      */
-    private function getGather(AbstractModel $model)
+    protected function getGather(AbstractModel $model)
     {
         return Utils::getPart($this->getOptionGatherMethods(), $model->getCleanName());
     }
@@ -991,7 +991,7 @@ class Generator implements \JsonSerializable
      * @param array $jsonArrayEntry
      * @return AbstractModel
      */
-    private static function getModelInstanceFromJsonArrayEntry(Generator $generator, array $jsonArrayEntry)
+    protected static function getModelInstanceFromJsonArrayEntry(Generator $generator, array $jsonArrayEntry)
     {
         return AbstractModel::instanceFromSerializedJson($generator, $jsonArrayEntry);
     }

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -816,7 +816,7 @@ class Generator implements \JsonSerializable
     }
     /**
      * Sets the optionSchemasFolder value
-     * @param bool $optionSchemasFolder
+     * @param string $optionSchemasFolder
      * @return Generator
      */
     public function setOptionSchemasFolder($optionSchemasFolder)

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -638,7 +638,7 @@ class Generator implements \JsonSerializable
         return $this;
     }
     /**
-     * Gets the optionSrcDiname value
+     * Gets the optionSrcDirname value
      * @return string
      */
     public function getOptionSrcDirname()
@@ -904,8 +904,8 @@ class Generator implements \JsonSerializable
     {
         if (strpos($url, '://') !== false) {
             $content = Utils::getContentFromUrl($url, $this->getOptionBasicLogin(), $this->getOptionBasicPassword(), $this->getOptionProxyHost(), $this->getOptionProxyPort(), $this->getOptionProxyLogin(), $this->getOptionProxyPassword(), $this->getSoapClient()->getSoapClientStreamContextOptions());
-            if ($this->getOptions()->getSchemasSave() === true) {
-                Utils::saveSchemas($this->getOptions()->getDestination(), $this->getOptions()->getSchemasFolder(), $url, $content);
+            if ($this->getOptionSchemasSave() === true) {
+                Utils::saveSchemas($this->getOptionDestination(), $this->getOptionSchemasFolder(), $url, $content);
             }
             return $content;
         } elseif (is_file($url)) {

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -867,7 +867,38 @@ class Generator implements \JsonSerializable
     public function getUrlContent($url)
     {
         if (strpos($url, '://') !== false) {
-            return Utils::getContentFromUrl($url, $this->getOptionBasicLogin(), $this->getOptionBasicPassword(), $this->getOptionProxyHost(), $this->getOptionProxyPort(), $this->getOptionProxyLogin(), $this->getOptionProxyPassword(), $this->getSoapClient()->getSoapClientStreamContextOptions());
+            $content = Utils::getContentFromUrl(
+                $url, 
+                $this->getOptionBasicLogin(), 
+                $this->getOptionBasicPassword(), 
+                $this->getOptionProxyHost(), 
+                $this->getOptionProxyPort(), 
+                $this->getOptionProxyLogin(), 
+                $this->getOptionProxyPassword(), 
+                $this->getSoapClient()->getSoapClientStreamContextOptions()
+            );
+            if($this->getOptions()->getSchemasSave() === true) {
+                $schemasFolder = $this->getOptions()->getSchemasFolder();
+                if(($schemasFolder == null) || empty($schemasFolder)) {
+                  $schemasFolder = 'wsdl';
+                }
+                $directory = rtrim($this->getOptions()->getDestination(), DIRECTORY_SEPARATOR)
+                    . DIRECTORY_SEPARATOR
+                    . rtrim($schemasFolder, DIRECTORY_SEPARATOR);
+                // @todo Cover all possible variants
+                if(
+                    (strpos(strtolower($url),'.wsdl') !== false) 
+                    || (strpos(strtolower($url),'.xsd') !== false) 
+                    || (strpos(strtolower($url),'.xml') !== false)
+                ) {
+                    $filename = basename($url);
+                } else {
+                    $filename = 'schema.wsdl';
+                }
+                Utils::createDirectory($directory);
+                file_put_contents($directory . DIRECTORY_SEPARATOR . $filename, $content);
+            }
+            return $content;
         } elseif (is_file($url)) {
             return file_get_contents($url);
         }

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -657,7 +657,7 @@ class Generator implements \JsonSerializable
     }
     /**
      * Gets the optionSoapOptions value
-     * @return string
+     * @return array
      */
     public function getOptionSoapOptions()
     {
@@ -950,7 +950,7 @@ class Generator implements \JsonSerializable
             foreach ($decodedJson['containers']['services'] as $service) {
                 $instance->getContainers()->getServices()->add(self::getModelInstanceFromJsonArrayEntry($instance, $service));
             }
-            // load sructs
+            // load structs
             foreach ($decodedJson['containers']['structs'] as $struct) {
                 $instance->getContainers()->getStructs()->add(self::getModelInstanceFromJsonArrayEntry($instance, $struct));
             }

--- a/src/Generator/GeneratorContainers.php
+++ b/src/Generator/GeneratorContainers.php
@@ -11,12 +11,12 @@ class GeneratorContainers extends AbstractGeneratorAware implements \JsonSeriali
      * Structs
      * @var StructContainer
      */
-    private $structs;
+    protected $structs;
     /**
      * Services
      * @var ServiceContainer
      */
-    private $services;
+    protected $services;
     /**
      * @param Generator $generator
      */

--- a/src/Generator/GeneratorFiles.php
+++ b/src/Generator/GeneratorFiles.php
@@ -18,7 +18,7 @@ class GeneratorFiles extends AbstractGeneratorAware
      * Use classmap file object
      * @var ClassMapFile
      */
-    private $classmapFile;
+    protected $classmapFile;
     /**
      * @return ClassMapFile
      */

--- a/src/Generator/Utils.php
+++ b/src/Generator/Utils.php
@@ -256,11 +256,13 @@ class Utils
      */
     public static function saveSchemas($destinationFolder, $schemasFolder, $schemasUrl, $content)
     {
-        if (($schemasFolder == null) || empty($schemasFolder)) {
+        if (($schemasFolder === null) || empty($schemasFolder)) {
+            // if null or empty schemas folder was provided
+            // default schemas folder will be wsdl
             $schemasFolder = 'wsdl';
         }
         $schemasPath = rtrim($destinationFolder, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . rtrim($schemasFolder, DIRECTORY_SEPARATOR);
-        // @todo Cover all possible variants
+        // Here we must cover all possible variants
         if ((strpos(strtolower($schemasUrl), '.wsdl') !== false) || (strpos(strtolower($schemasUrl), '.xsd') !== false) || (strpos(strtolower($schemasUrl), '.xml') !== false)) {
             $filename = basename($schemasUrl);
         } else {

--- a/src/Generator/Utils.php
+++ b/src/Generator/Utils.php
@@ -7,7 +7,7 @@ use WsdlToPhp\PackageGenerator\ConfigurationReader\GeneratorOptions;
 class Utils
 {
     /**
-     * Gets upper case word admong a string from the end or from the beginning part
+     * Gets upper case word among a string from the end or from the beginning part
      * @param string $optionValue
      * @param string $string the string from which we can extract the part
      * @return string
@@ -211,7 +211,7 @@ class Utils
      * See more about the used regular expression at {@link http://www.regular-expressions.info/unicode.html}:
      * - \p{L} for any valid letter
      * - \p{N} for any valid number
-     * - /u for suporting unicode
+     * - /u for supporting unicode
      * @param string $string the string to clean
      * @param bool $keepMultipleUnderscores optional, allows to keep the multiple consecutive underscores
      * @return string

--- a/src/Generator/Utils.php
+++ b/src/Generator/Utils.php
@@ -266,7 +266,7 @@ class Utils
             // if $url is like http://example.com/index.php?WSDL default filename will be schema.wsdl
             $filename = 'schema.wsdl';
         }
-        self::createDirectory($schemasFolder);
+        self::createDirectory($schemasPath);
         file_put_contents($schemasPath . DIRECTORY_SEPARATOR . $filename, $content);
     }
 }

--- a/src/Generator/Utils.php
+++ b/src/Generator/Utils.php
@@ -245,4 +245,28 @@ class Utils
         }
         return true;
     }
+    /**
+     * Save schemas to schemasFolder
+     * Filename will be extracted from schemasUrl or default schema.wsdl will be used
+     * @param string $destinationFolder
+     * @param string $schemasFolder
+     * @param string $schemasUrl
+     * @param string $content
+     */
+    public static function saveSchemas($destinationFolder, $schemasFolder, $schemasUrl, $content)
+    {
+        if (($schemasFolder == null) || empty($schemasFolder)) {
+            $schemasFolder = 'wsdl';
+        }
+        $schemasPath = rtrim($destinationFolder, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . rtrim($schemasFolder, DIRECTORY_SEPARATOR);
+        // @todo Cover all possible variants
+        if ((strpos(strtolower($schemasUrl), '.wsdl') !== false) || (strpos(strtolower($schemasUrl), '.xsd') !== false) || (strpos(strtolower($schemasUrl), '.xml') !== false)) {
+            $filename = basename($schemasUrl);
+        } else {
+            // if $url is like http://example.com/index.php?WSDL default filename will be schema.wsdl
+            $filename = 'schema.wsdl';
+        }
+        self::createDirectory($schemasFolder);
+        file_put_contents($schemasPath . DIRECTORY_SEPARATOR . $filename, $content);
+    }
 }

--- a/src/Generator/Utils.php
+++ b/src/Generator/Utils.php
@@ -252,6 +252,7 @@ class Utils
      * @param string $schemasFolder
      * @param string $schemasUrl
      * @param string $content
+     * @return string
      */
     public static function saveSchemas($destinationFolder, $schemasFolder, $schemasUrl, $content)
     {
@@ -268,5 +269,6 @@ class Utils
         }
         self::createDirectory($schemasPath);
         file_put_contents($schemasPath . DIRECTORY_SEPARATOR . $filename, $content);
+        return $schemasPath . DIRECTORY_SEPARATOR . $filename;
     }
 }

--- a/src/Model/AbstractModel.php
+++ b/src/Model/AbstractModel.php
@@ -40,7 +40,7 @@ abstract class AbstractModel extends AbstractGeneratorAware implements \JsonSeri
      */
     protected $owner = null;
     /**
-     * Indicates that the current elemen is an abstract element.
+     * Indicates that the current element is an abstract element.
      * It allows to generated an abstract class.
      * This will happen for element/complexType that are defined with abstract="true"
      * @var bool
@@ -57,7 +57,7 @@ abstract class AbstractModel extends AbstractGeneratorAware implements \JsonSeri
      */
     protected $replacedReservedMethods = [];
     /**
-     * Unique name generated in order to ensure unique naming (for struct constructor and setters/getters even for different case attribute name whith same value)
+     * Unique name generated in order to ensure unique naming (for struct constructor and setters/getters even for different case attribute name with same value)
      * @var array
      */
     protected static $uniqueNames = [];
@@ -290,6 +290,7 @@ abstract class AbstractModel extends AbstractGeneratorAware implements \JsonSeri
      * @uses Generator::getOptionPrefix()
      * @uses Generator::getOptionSuffix()
      * @uses AbstractModel::uniqueName() to ensure unique naming of struct case sensitively
+     * @param bool $namespaced
      * @return string
      */
     public function getPackagedName($namespaced = false)
@@ -319,7 +320,7 @@ abstract class AbstractModel extends AbstractGeneratorAware implements \JsonSeri
         return '';
     }
     /**
-     * Allows to define from which class the curent model extends
+     * Allows to define from which class the current model extends
      * @param bool $short
      * @return string|null
      */
@@ -451,7 +452,7 @@ abstract class AbstractModel extends AbstractGeneratorAware implements \JsonSeri
         }
     }
     /**
-     * Static method wich returns a unique name case sensitively
+     * Static method which returns a unique name case sensitively
      * Useful to name methods case sensitively distinct, see http://the-echoplex.net/log/php-case-sensitivity
      * @param string $name the original name
      * @param string $context the context where the name is needed unique

--- a/src/Model/AbstractModel.php
+++ b/src/Model/AbstractModel.php
@@ -23,44 +23,44 @@ abstract class AbstractModel extends AbstractGeneratorAware implements \JsonSeri
      * Original name od the element
      * @var string
      */
-    private $name = '';
+    protected $name = '';
     /**
      * Values associated to the operation
      * @var string[]
      */
-    private $meta = [];
+    protected $meta = [];
     /**
      * Define the inheritance of a struct by the name of the parent struct or type
      * @var string
      */
-    private $inheritance = '';
+    protected $inheritance = '';
     /**
      * Store the object which owns the current model
      * @var AbstractModel
      */
-    private $owner = null;
+    protected $owner = null;
     /**
      * Indicates that the current elemen is an abstract element.
      * It allows to generated an abstract class.
      * This will happen for element/complexType that are defined with abstract="true"
      * @var bool
      */
-    private $isAbstract = false;
+    protected $isAbstract = false;
     /**
      * Replaced keywords time in order to generate unique new keyword
      * @var array
      */
-    private static $replacedPhpReservedKeywords = [];
+    protected static $replacedPhpReservedKeywords = [];
     /**
      * Replaced methods time in order to generate unique new method
      * @var array
      */
-    private $replacedReservedMethods = [];
+    protected $replacedReservedMethods = [];
     /**
      * Unique name generated in order to ensure unique naming (for struct constructor and setters/getters even for different case attribute name whith same value)
      * @var array
      */
-    private static $uniqueNames = [];
+    protected static $uniqueNames = [];
     /**
      * Main constructor
      * @uses AbstractModel::setName()
@@ -531,7 +531,7 @@ abstract class AbstractModel extends AbstractGeneratorAware implements \JsonSeri
      * @param array $args
      * @throws \InvalidArgumentException
      */
-    private static function checkSerializedJson(array $args)
+    protected static function checkSerializedJson(array $args)
     {
         if (!array_key_exists('__CLASS__', $args)) {
             throw new \InvalidArgumentException(sprintf('__CLASS__ key is missing from', var_export($args, true)));

--- a/src/Model/Method.php
+++ b/src/Model/Method.php
@@ -51,6 +51,7 @@ class Method extends AbstractModel
     /**
      * Method name can't starts with numbers
      * @see \WsdlToPhp\PackageGenerator\Model\AbstractModel::getCleanName()
+     * @param bool $keepMultipleUnderscores
      * @return string
      */
     public function getCleanName($keepMultipleUnderscores = true)
@@ -107,7 +108,7 @@ class Method extends AbstractModel
         return $this;
     }
     /**
-     * Returns the retrun type
+     * Returns the return type
      * @return string
      */
     public function getReturnType()
@@ -115,7 +116,7 @@ class Method extends AbstractModel
         return $this->returnType;
     }
     /**
-     * Set the retrun type
+     * Set the return type
      * @param string|string[]
      * @return Method
      */

--- a/src/Model/Method.php
+++ b/src/Model/Method.php
@@ -14,22 +14,22 @@ class Method extends AbstractModel
      * Type of the parameter for the operation
      * @var string
      */
-    private $parameterType = '';
+    protected $parameterType = '';
     /**
      * Type of the return value for the operation
      * @var string
      */
-    private $returnType = '';
+    protected $returnType = '';
     /**
      * Indicates function is not alone with this name, then its name is contextualized based on its parameter(s)
      * @var bool
      */
-    private $isUnique = true;
+    protected $isUnique = true;
     /**
      * Generated method name stored as soon as it has been defined once
      * @var string
      */
-    private $methodName = null;
+    protected $methodName = null;
     /**
      * Main constructor
      * @see AbstractModel::__construct()

--- a/src/Model/Service.php
+++ b/src/Model/Service.php
@@ -20,7 +20,7 @@ class Service extends AbstractModel
      * Store the methods of the service
      * @var MethodContainer
      */
-    private $methods;
+    protected $methods;
     /**
      * Main constructor
      * @see AbstractModel::__construct()
@@ -67,7 +67,7 @@ class Service extends AbstractModel
      * @param MethodContainer $methodContainer
      * @return Service
      */
-    private function setMethods(MethodContainer $methodContainer)
+    protected function setMethods(MethodContainer $methodContainer)
     {
         $this->methods = $methodContainer;
         return $this;

--- a/src/Model/Service.php
+++ b/src/Model/Service.php
@@ -99,7 +99,7 @@ class Service extends AbstractModel
         return $this->methods->getMethodByName($methodName);
     }
     /**
-     * Allows to define from which class the curent model extends
+     * Allows to define from which class the current model extends
      * @param bool $short
      * @return string
      */

--- a/src/Model/Struct.php
+++ b/src/Model/Struct.php
@@ -30,27 +30,27 @@ class Struct extends AbstractModel
      * Attributes of the struct
      * @var StructAttributeContainer
      */
-    private $attributes;
+    protected $attributes;
     /**
      * Is the struct a restriction with defined values  ?
      * @var bool
      */
-    private $isRestriction = false;
+    protected $isRestriction = false;
     /**
      * If the struct is a restriction with values, then store values
      * @var StructValueContainer
      */
-    private $values;
+    protected $values;
     /**
      * If the struct is a union with types, then store types
      * @var string[]
      */
-    private $types;
+    protected $types;
     /**
-     * Define if the urrent struct is a concrete struct or just a virtual struct to store meta informations
+     * Define if the current struct is a concrete struct or just a virtual struct to store meta informations
      * @var bool
      */
-    private $isStruct = false;
+    protected $isStruct = false;
     /**
      * Main constructor
      * @see AbstractModel::__construct()

--- a/src/Model/Struct.php
+++ b/src/Model/Struct.php
@@ -57,7 +57,7 @@ class Struct extends AbstractModel
      * @uses Struct::setStruct()
      * @param Generator $generator
      * @param string $name the original name
-     * @param bool $isStruct defines if it's a real sruct or not
+     * @param bool $isStruct defines if it's a real struct or not
      * @param bool $isRestriction defines if it's an enumeration or not
      */
     public function __construct(Generator $generator, $name, $isStruct = true, $isRestriction = false)
@@ -116,7 +116,7 @@ class Struct extends AbstractModel
      * @uses Struct::isStruct()
      * @uses Struct::getAttributes()
      * @param bool $includeInheritanceAttributes include the attributes of parent class, default parent attributes are not included. If true, then the array is an associative array containing and index "attribute" for the StructAttribute object and an index "model" for the Struct object.
-     * @param bool $requiredFirst places the required attributes first, then the not required in order to have the _contrust method with the required attribute at first
+     * @param bool $requiredFirst places the required attributes first, then the not required in order to have the _construct method with the required attribute at first
      * @return StructAttributeContainer
      */
     public function getAttributes($includeInheritanceAttributes = false, $requiredFirst = false)
@@ -327,7 +327,7 @@ class Struct extends AbstractModel
         return $this->values->getStructValueByName($value);
     }
     /**
-     * Allows to define from which class the curent model extends
+     * Allows to define from which class the current model extends
      * @param bool $short
      * @return string
      */

--- a/src/Model/StructAttribute.php
+++ b/src/Model/StructAttribute.php
@@ -16,20 +16,20 @@ class StructAttribute extends AbstractModel
      * Type of the struct attribute
      * @var string
      */
-    private $type = '';
+    protected $type = '';
     /**
      * Defines that this property is not a simple value but an array of values
      * Infos at {@link https://www.w3.org/TR/xmlschema-0/#OccurrenceConstraints}
      * @var bool
      */
-    private $containsElements = false;
+    protected $containsElements = false;
     /**
      * Defines that this property can be removed from request or not.
      * The property cna be removed from the request (meaning from the Struct) as soon as the nillable=true && minOccurs=0
      * Infos at {@link http://www.w3schools.com/xml/el_element.asp}
      * @var bool
      */
-    private $removableFromRequest = false;
+    protected $removableFromRequest = false;
     /**
      * Main constructor
      * @see AbstractModel::__construct()

--- a/src/Model/StructAttribute.php
+++ b/src/Model/StructAttribute.php
@@ -46,17 +46,17 @@ class StructAttribute extends AbstractModel
         $this->setType($type)->setOwner($struct);
     }
     /**
-     * Returns the unique name in the current struct (for setters/getters and struct contrusctor array)
+     * Returns the unique name in the current struct (for setters/getters and struct constructor array)
      * @uses AbstractModel::getCleanName()
      * @uses AbstractModel::getName()
      * @uses AbstractModel::uniqueName()
      * @uses StructAttribute::getOwner()
-     * @param string $additionnalContext
+     * @param string $additionalContext
      * @return string
      */
-    public function getUniqueName($additionnalContext = '')
+    public function getUniqueName($additionalContext = '')
     {
-        return self::uniqueName($this->getCleanName(), $this->getOwner()->getName() . $additionnalContext);
+        return self::uniqueName($this->getCleanName(), $this->getOwner()->getName() . $additionalContext);
     }
     /**
      * Returns the getter name for this attribute

--- a/src/Model/StructValue.php
+++ b/src/Model/StructValue.php
@@ -22,12 +22,12 @@ class StructValue extends AbstractModel
      * Store the constants generated per structName
      * @var array
      */
-    private static $uniqueConstants = [];
+    protected static $uniqueConstants = [];
     /**
      * The index of the value in the enumeration struct
      * @var int
      */
-    private $index = 0;
+    protected $index = 0;
     /**
      * Main constructor
      * @see AbstractModel::__construct()
@@ -114,7 +114,7 @@ class StructValue extends AbstractModel
      * @param int $index the position of the value
      * @return int
      */
-    private static function constantSuffix($structName, $value, $index)
+    protected static function constantSuffix($structName, $value, $index)
     {
         $key = strtoupper($structName . '_' . $value);
         $indexedKey = $key . '_' . $index;

--- a/src/Model/StructValue.php
+++ b/src/Model/StructValue.php
@@ -35,7 +35,7 @@ class StructValue extends AbstractModel
      * @uses StructValue::setIndex()
      * @param Generator $generator
      * @param string $name the original name
-     * @param string $index the index of the value in the enumeration struct
+     * @param int|string $index the index of the value in the enumeration struct
      * @param Struct $struct defines the struct which owns this value
      */
     public function __construct(Generator $generator, $name, $index = 0, Struct $struct = null)
@@ -108,7 +108,7 @@ class StructValue extends AbstractModel
     }
     /**
      * Returns the index which has to be added at the end of natural constant name defined with the value cleaned
-     * Allows to avoid multiple constant name to be indentic
+     * Allows to avoid multiple constant name to be identical
      * @param string $structName the struct name
      * @param string $value the value
      * @param int $index the position of the value

--- a/src/Parser/SoapClient/Structs.php
+++ b/src/Parser/SoapClient/Structs.php
@@ -23,7 +23,7 @@ class Structs extends AbstractParser
     /**
      * @var string[]
      */
-    private $definedStructs = [];
+    protected $definedStructs = [];
     /**
      * Parses the SoapClient types
      * @see \WsdlToPhp\PackageGenerator\Parser\ParserInterface::parse()
@@ -122,7 +122,7 @@ class Structs extends AbstractParser
      * @param string $type
      * @return boolean
      */
-    private function isStructDefined($type)
+    protected function isStructDefined($type)
     {
         return in_array(self::typeSignature($type), $this->definedStructs);
     }
@@ -130,7 +130,7 @@ class Structs extends AbstractParser
      * @param string $type
      * @return Structs
      */
-    private function structHasBeenDefined($type)
+    protected function structHasBeenDefined($type)
     {
         $this->definedStructs[] = self::typeSignature($type);
         return $this;
@@ -139,7 +139,7 @@ class Structs extends AbstractParser
      * @param string $type
      * @return string
      */
-    private static function typeSignature($type)
+    protected static function typeSignature($type)
     {
         return md5($type);
     }

--- a/src/Parser/Wsdl/AbstractParser.php
+++ b/src/Parser/Wsdl/AbstractParser.php
@@ -24,12 +24,12 @@ abstract class AbstractParser extends Parser
      * List of Wsdl parsed for the current tag
      * @var array
      */
-    private $parsedWsdls;
+    protected $parsedWsdls;
     /**
      * List of Schema parsed for the current tag
      * @var array
      */
-    private $parsedSchemas;
+    protected $parsedSchemas;
     /**
      *
      * @param Generator $generator
@@ -85,7 +85,7 @@ abstract class AbstractParser extends Parser
      * @param AbstractTag[] $tags
      * @return \WsdlToPhp\PackageGenerator\Parser\Wsdl\AbstractParser
      */
-    private function setTags(array $tags)
+    protected function setTags(array $tags)
     {
         $this->tags = $tags;
         return $this;
@@ -101,7 +101,7 @@ abstract class AbstractParser extends Parser
      * @param Wsdl $wsdl
      * @return AbstractParser
      */
-    private function setWsdlAsParsed(Wsdl $wsdl)
+    protected function setWsdlAsParsed(Wsdl $wsdl)
     {
         if (!array_key_exists($wsdl->getName(), $this->parsedWsdls)) {
             $this->parsedWsdls[$wsdl->getName()] = [];
@@ -122,7 +122,7 @@ abstract class AbstractParser extends Parser
      * @param Schema $schema
      * @return AbstractParser
      */
-    private function setSchemaAsParsed(Wsdl $wsdl, Schema $schema)
+    protected function setSchemaAsParsed(Wsdl $wsdl, Schema $schema)
     {
         $key = $wsdl->getName() . $schema->getName();
         if (!array_key_exists($key, $this->parsedSchemas)) {

--- a/src/Parser/Wsdl/AbstractTagImportParser.php
+++ b/src/Parser/Wsdl/AbstractTagImportParser.php
@@ -55,7 +55,7 @@ abstract class AbstractTagImportParser extends AbstractTagParser
     /**
      * @return AbstractTagImportParser
      */
-    private function getTagParser()
+    protected function getTagParser()
     {
         $tagName = null;
         switch ($this->parsingTag()) {

--- a/src/Parser/Wsdl/AbstractTagInputOutputParser.php
+++ b/src/Parser/Wsdl/AbstractTagInputOutputParser.php
@@ -23,6 +23,7 @@ abstract class AbstractTagInputOutputParser extends AbstractTagParser
     abstract protected function setKnownType(Method $method, $knownType);
     /**
      * @see \WsdlToPhp\PackageGenerator\Parser\Wsdl\AbstractParser::parseWsdl()
+     * @param Wsdl $wsdl
      */
     protected function parseWsdl(Wsdl $wsdl)
     {

--- a/src/Parser/Wsdl/AbstractTagInputOutputParser.php
+++ b/src/Parser/Wsdl/AbstractTagInputOutputParser.php
@@ -79,7 +79,7 @@ abstract class AbstractTagInputOutputParser extends AbstractTagParser
      * @param Method $method
      * @return boolean
      */
-    private function isKnownTypeUnknown(Method $method)
+    protected function isKnownTypeUnknown(Method $method)
     {
         $isKnown = true;
         $knownType = $this->getKnownType($method);

--- a/src/Parser/Wsdl/AbstractTagParser.php
+++ b/src/Parser/Wsdl/AbstractTagParser.php
@@ -94,7 +94,7 @@ abstract class AbstractTagParser extends AbstractParser
     }
     /**
      * @param string $tagName
-     * @return string
+     * @return array|null
      */
     protected function getParseTagAttributeMethod($tagName)
     {

--- a/src/WsdlHandler/Tag/AbstractTag.php
+++ b/src/WsdlHandler/Tag/AbstractTag.php
@@ -104,6 +104,9 @@ abstract class AbstractTag extends ElementHandler
         return $this->hasAttribute(Attribute::ATTRIBUTE_VALUE);
     }
     /**
+     * @param bool $withNamespace
+     * @param bool $withinItsType
+     * @param string $asType
      * @return mixed
      */
     public function getValueAttributeValue($withNamespace = false, $withinItsType = true, $asType = null)
@@ -119,6 +122,7 @@ abstract class AbstractTag extends ElementHandler
     }
     /**
      * @see \WsdlToPhp\DomHandler\AbstractElementHandler::getChildrenByName()
+     * @param string $name
      * @return AbstractTag[]
      */
     public function getChildrenByName($name)

--- a/src/WsdlHandler/Tag/TagPart.php
+++ b/src/WsdlHandler/Tag/TagPart.php
@@ -36,7 +36,7 @@ class TagPart extends Tag
      * @param bool $returnValue
      * @return AttributeHandler|mixed
      */
-    private function getAttributeMixedValue($attributeName, $returnValue = true)
+    protected function getAttributeMixedValue($attributeName, $returnValue = true)
     {
         $value = $this->getAttribute($attributeName);
         if ($returnValue === true && $value instanceof AttributeHandler) {

--- a/src/WsdlHandler/Wsdl.php
+++ b/src/WsdlHandler/Wsdl.php
@@ -103,7 +103,7 @@ class Wsdl extends AbstractDocument
      * @param bool $returnOne
      * @return mixed
      */
-    private function useParentMethodAndExternals($method, $parameters, $includeExternals = false, $returnOne = false)
+    protected function useParentMethodAndExternals($method, $parameters, $includeExternals = false, $returnOne = false)
     {
         $result = call_user_func_array([
             $this,
@@ -120,7 +120,7 @@ class Wsdl extends AbstractDocument
      * @param bool $returnOne
      * @return mixed
      */
-    private function useExternalSchemas($method, $parameters, $parentResult, $returnOne = false)
+    protected function useExternalSchemas($method, $parameters, $parentResult, $returnOne = false)
     {
         $result = $parentResult;
         if ($this->getExternalSchemas()->count() > 0) {

--- a/src/resources/config/generator_options.yml
+++ b/src/resources/config/generator_options.yml
@@ -89,3 +89,9 @@ enums_folder:
 services_folder:
     default: 'ServiceType'
     values: ''
+schemas_save:
+    default: false
+    values: [ true, false ]
+schemas_folder:
+    default: 'wsdl'
+    values: ''

--- a/tests/ConfigurationReader/GeneratorOptionsTest.php
+++ b/tests/ConfigurationReader/GeneratorOptionsTest.php
@@ -585,6 +585,26 @@ class GeneratorOptionsTest extends TestCase
     /**
      *
      */
+    public function testSetSchemasSave()
+    {
+        $instance = self::optionsInstance();
+        $instance->setSchemasSave(false);
+
+        $this->assertSame(false, $instance->getSchemasSave());
+    }
+    /**
+     *
+     */
+    public function testSetSchemasFolder()
+    {
+        $instance = self::optionsInstance();
+        $instance->setSchemasFolder('wsdl');
+
+        $this->assertSame('wsdl', $instance->getSchemasFolder());
+    }
+    /**
+     *
+     */
     public function testSetExistingOptionValue()
     {
         $instance = self::optionsInstance();
@@ -662,6 +682,8 @@ class GeneratorOptionsTest extends TestCase
             'arrays_folder' => 'ArrayType',
             'enums_folder' => 'EnumType',
             'services_folder' => 'ServiceType',
+            'schemas_save' => false,
+            'schemas_folder' => 'wsdl',
         ], self::optionsInstance()->toArray());
     }
     /**
@@ -699,6 +721,8 @@ class GeneratorOptionsTest extends TestCase
             'arrays_folder' => 'ArrayType',
             'enums_folder' => 'EnumType',
             'services_folder' => 'ServiceType',
+            'schemas_save' => false,
+            'schemas_folder' => 'wsdl',
         ], self::optionsInstance()->jsonSerialize());
     }
 }

--- a/tests/Generator/GeneratorTest.php
+++ b/tests/Generator/GeneratorTest.php
@@ -520,6 +520,26 @@ class GeneratorTest extends TestCase
     /**
      *
      */
+    public function testSetSchemasSave()
+    {
+        $instance = self::getBingGeneratorInstance();
+        $instance->setOptionSchemasSave(false);
+
+        $this->assertSame(false, $instance->getOptionSchemasSave());
+    }
+    /**
+     *
+     */
+    public function testSetSchemasFolder()
+    {
+        $instance = self::getBingGeneratorInstance();
+        $instance->setOptionSchemasFolder('wsdl');
+
+        $this->assertSame('wsdl', $instance->getOptionSchemasFolder());
+    }
+    /**
+     *
+     */
     public function testSetPackageNameUcFirst()
     {
         $instance = self::getBingGeneratorInstance();
@@ -616,6 +636,8 @@ class GeneratorTest extends TestCase
             ->setProxyPassword('')
             ->setProxyPort('')
             ->setServicesFolder('ServiceType')
+            ->setSchemasSave(false)
+            ->setSchemasFolder('wsdl')
             ->setSoapClientClass('\WsdlToPhp\PackageBase\AbstractSoapClientBase')
             ->setSoapOptions([])
             ->setStandalone($standalone)
@@ -667,7 +689,7 @@ class GeneratorTest extends TestCase
     {
         $instance = self::getBingGeneratorInstance();
 
-        if (PHP_VERSION_ID < 70015) {
+        if (PHP_VERSION_ID < 70107) {
             $this->assertSame([], $instance->getSoapClient()->getSoapClientStreamContextOptions());
         } else {
             $this->assertSame([

--- a/tests/Generator/GeneratorTest.php
+++ b/tests/Generator/GeneratorTest.php
@@ -689,7 +689,7 @@ class GeneratorTest extends TestCase
     {
         $instance = self::getBingGeneratorInstance();
 
-        if (PHP_VERSION_ID < 70107) {
+        if (PHP_VERSION_ID < 70015) {
             $this->assertSame([], $instance->getSoapClient()->getSoapClientStreamContextOptions());
         } else {
             $this->assertSame([

--- a/tests/Generator/GeneratorTest.php
+++ b/tests/Generator/GeneratorTest.php
@@ -663,10 +663,13 @@ class GeneratorTest extends TestCase
     public function testGetUrlContent()
     {
         $generator = self::getBingGeneratorInstance();
+        $content = $generator->getUrlContent('http://api.search.live.net/search.wsdl');
+        $this->assertNotNull($content);
 
-        $phar = $generator->getUrlContent('https://phar.wsdltophp.com/wsdltophp.phar');
-
-        $this->assertNotNull($phar);
+        $generator->setOptionSchemasSave(true);
+        $generator->setOptionSchemasFolder('wsdl');
+        $content = $generator->getUrlContent('http://api.search.live.net/search.wsdl');
+        $this->assertNotNull($content);
     }
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/Generator/UtilsTest.php
+++ b/tests/Generator/UtilsTest.php
@@ -193,9 +193,15 @@ class UtilsTest extends TestCase
     {
         $path = __DIR__ . '/../resources/generated';
         $wsdlFolder = 'schema_save_folder';
+        // test file name extracted from url
         $this->assertSame($path . '/' . $wsdlFolder . '/webservice.wsdl', Utils::saveSchemas($path, $wsdlFolder, 'http://www.foo.com/webservice.wsdl', '<Text>Save schema to folder</Text>'));
+        // test file name not set in url 
         $this->assertSame($path . '/' . $wsdlFolder . '/schema.wsdl', Utils::saveSchemas($path, $wsdlFolder, 'http://www.foo.com/index.php?WSDL', '<Text>Save schema to folder</Text>'));
+        // test save folder is empty
+        $this->assertSame($path . '/wsdl/schema.wsdl', Utils::saveSchemas($path, '', 'http://www.foo.com/index.php?WSDL', '<Text>Save schema to folder</Text>'));
+        // test get saved content
         $this->assertSame('<Text>Save schema to folder</Text>', file_get_contents($path . '/' . $wsdlFolder . '/webservice.wsdl'));
         $this->assertSame('<Text>Save schema to folder</Text>', file_get_contents($path . '/' . $wsdlFolder . '/schema.wsdl'));
+        $this->assertSame('<Text>Save schema to folder</Text>', file_get_contents($path . '/wsdl/schema.wsdl'));
     }
 }

--- a/tests/Generator/UtilsTest.php
+++ b/tests/Generator/UtilsTest.php
@@ -186,4 +186,16 @@ class UtilsTest extends TestCase
         $this->assertSame('äöüß', Utils::cleanString('äöüß'));
         $this->assertSame('θωερτψυιοπασδφγηςκλζχξωβνμάέήίϊΐόύϋΰώ', 'θωερτψυιοπασδφγηςκλζχξωβνμάέήίϊΐόύϋΰώ');
     }
+    /**
+     * 
+     */
+    public function testSaveSchemas()
+    {
+        $path = __DIR__ . '/../resources/generated';
+        $wsdlFolder = 'schema_save_folder';
+        $this->assertSame($path . '/' . $wsdlFolder . '/webservice.wsdl', Utils::saveSchemas($path, $wsdlFolder, 'http://www.foo.com/webservice.wsdl', '<Text>Save schema to folder</Text>'));
+        $this->assertSame($path . '/' . $wsdlFolder . '/schema.wsdl', Utils::saveSchemas($path, $wsdlFolder, 'http://www.foo.com/index.php?WSDL', '<Text>Save schema to folder</Text>'));
+        $this->assertSame('<Text>Save schema to folder</Text>', file_get_contents($path . '/' . $wsdlFolder . '/webservice.wsdl'));
+        $this->assertSame('<Text>Save schema to folder</Text>', file_get_contents($path . '/' . $wsdlFolder . '/schema.wsdl'));
+    }
 }

--- a/tests/generate_serialized_jsons.php
+++ b/tests/generate_serialized_jsons.php
@@ -150,7 +150,9 @@ foreach ($jsons as $id => $settings) {
             ->setOrigin($settings['origin'])
             ->setGatherMethods($gatherMethod)
             ->setPrefix('Api')
-            ->setDestination(TestCase::getTestDirectory());
+            ->setDestination(TestCase::getTestDirectory())
+            ->setSchemasSave(false)
+            ->setSchemasFolder('wsdl');
         $generator = new Generator($options);
         $generator->parse();
         $json = json_encode($generator, JSON_PRETTY_PRINT);

--- a/tests/resources/existing_config/wsdltophp.yml
+++ b/tests/resources/existing_config/wsdltophp.yml
@@ -83,3 +83,9 @@ enums_folder:
 services_folder:
     default: 'ServiceType'
     values: ''
+schemas_save:
+    default: false
+    values: [ true, false ]
+schemas_folder:
+    default: 'wsdl'
+    values: ''

--- a/tests/resources/generated/json_serialized.json
+++ b/tests/resources/generated/json_serialized.json
@@ -3309,6 +3309,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_actonservice2_none.json
+++ b/tests/resources/generated/parsed_actonservice2_none.json
@@ -3500,6 +3500,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_actonservice2_start.json
+++ b/tests/resources/generated/parsed_actonservice2_start.json
@@ -3500,6 +3500,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_bingsearch_none.json
+++ b/tests/resources/generated/parsed_bingsearch_none.json
@@ -3311,6 +3311,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_bingsearch_start.json
+++ b/tests/resources/generated/parsed_bingsearch_start.json
@@ -3311,6 +3311,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_deliveryservice_none.json
+++ b/tests/resources/generated/parsed_deliveryservice_none.json
@@ -11807,6 +11807,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_deliveryservice_start.json
+++ b/tests/resources/generated/parsed_deliveryservice_start.json
@@ -11564,6 +11564,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_docdatapayments_none.json
+++ b/tests/resources/generated/parsed_docdatapayments_none.json
@@ -8932,6 +8932,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_docdatapayments_start.json
+++ b/tests/resources/generated/parsed_docdatapayments_start.json
@@ -8923,6 +8923,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_ews_none.json
+++ b/tests/resources/generated/parsed_ews_none.json
@@ -80214,6 +80214,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_ews_start.json
+++ b/tests/resources/generated/parsed_ews_start.json
@@ -79584,6 +79584,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_odigeo_none.json
+++ b/tests/resources/generated/parsed_odigeo_none.json
@@ -1449,6 +1449,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_odigeo_start.json
+++ b/tests/resources/generated/parsed_odigeo_start.json
@@ -1449,6 +1449,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_omnitureadminservices_none.json
+++ b/tests/resources/generated/parsed_omnitureadminservices_none.json
@@ -23723,6 +23723,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_omnitureadminservices_start.json
+++ b/tests/resources/generated/parsed_omnitureadminservices_start.json
@@ -22067,6 +22067,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_ordercontract_none.json
+++ b/tests/resources/generated/parsed_ordercontract_none.json
@@ -5263,6 +5263,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_ordercontract_start.json
+++ b/tests/resources/generated/parsed_ordercontract_start.json
@@ -5245,6 +5245,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_paypal_none.json
+++ b/tests/resources/generated/parsed_paypal_none.json
@@ -43767,6 +43767,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_paypal_start.json
+++ b/tests/resources/generated/parsed_paypal_start.json
@@ -43470,6 +43470,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_portaplusapi_none.json
+++ b/tests/resources/generated/parsed_portaplusapi_none.json
@@ -1366,6 +1366,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_portaplusapi_start.json
+++ b/tests/resources/generated/parsed_portaplusapi_start.json
@@ -1105,6 +1105,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_queueservice_none.json
+++ b/tests/resources/generated/parsed_queueservice_none.json
@@ -2532,6 +2532,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_queueservice_start.json
+++ b/tests/resources/generated/parsed_queueservice_start.json
@@ -2478,6 +2478,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_reformagkh_none.json
+++ b/tests/resources/generated/parsed_reformagkh_none.json
@@ -15820,6 +15820,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_reformagkh_start.json
+++ b/tests/resources/generated/parsed_reformagkh_start.json
@@ -15685,6 +15685,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_wcf_none.json
+++ b/tests/resources/generated/parsed_wcf_none.json
@@ -264,6 +264,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_wcf_start.json
+++ b/tests/resources/generated/parsed_wcf_start.json
@@ -264,6 +264,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_whl_none.json
+++ b/tests/resources/generated/parsed_whl_none.json
@@ -15603,6 +15603,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_whl_start.json
+++ b/tests/resources/generated/parsed_whl_start.json
@@ -15567,6 +15567,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_yandex_campaigns_none.json
+++ b/tests/resources/generated/parsed_yandex_campaigns_none.json
@@ -7579,6 +7579,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_yandex_campaigns_start.json
+++ b/tests/resources/generated/parsed_yandex_campaigns_start.json
@@ -7579,6 +7579,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_yandex_groups_none.json
+++ b/tests/resources/generated/parsed_yandex_groups_none.json
@@ -2571,6 +2571,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_yandex_groups_start.json
+++ b/tests/resources/generated/parsed_yandex_groups_start.json
@@ -2571,6 +2571,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_yandex_live_none.json
+++ b/tests/resources/generated/parsed_yandex_live_none.json
@@ -12685,6 +12685,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generated/parsed_yandex_live_start.json
+++ b/tests/resources/generated/parsed_yandex_live_start.json
@@ -12190,6 +12190,8 @@
         "structs_folder": "StructType",
         "arrays_folder": "ArrayType",
         "enums_folder": "EnumType",
-        "services_folder": "ServiceType"
+        "services_folder": "ServiceType",
+        "schemas_save": false,
+        "schemas_folder": "wsdl"
     }
 }

--- a/tests/resources/generator_options.yml
+++ b/tests/resources/generator_options.yml
@@ -88,3 +88,9 @@ enums_folder:
 services_folder:
     default: 'ServiceType'
     values: ''
+schemas_save:
+    default: false
+    values: [ true, false ]
+schemas_folder:
+    default: 'wsdl'
+    values: ''

--- a/wsdltophp.yml.dist
+++ b/wsdltophp.yml.dist
@@ -92,3 +92,9 @@ enums_folder:
 services_folder:
     default: 'ServiceType'
     values: ''
+schemas_save:
+    default: false
+    values: [ true, false ]
+schemas_folder:
+    default: 'wsdl'
+    values: ''


### PR DESCRIPTION
**// Options for saving schemas locally**
**// Note: schamas save works only for urls origin**
$options = GeneratorOptions::instance(/* '/path/file.yml' */);
$options
    ->setOrigin('http://developer.ebay.com/webservices/latest/ebaySvc.wsdl')
    ->setDestination('./MySdk')
    ->setComposerName('myproject/mysdk')
    **->setSchemasSave(true)
    ->setSchemasFolder('wsdl')**;
// Generator instantiation
$generator = new Generator($options);
// Package generation
$generator->generatePackage();