### PR TITLE
Moved tests directory to the dev autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,11 @@
     },
     "autoload": {
         "psr-4": {
-            "WsdlToPhp\\PackageGenerator\\": "src",
+            "WsdlToPhp\\PackageGenerator\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "WsdlToPhp\\PackageGenerator\\Tests\\": "tests"
         }
     }


### PR DESCRIPTION
A project that includes `wsdltophp/packagegenerator` as a dependency should not need to autoload the unit test cases (or basically any class that resides inside the `tests` directory).

This PR moves the autoloading of the `WsdlToPhp\PackageGenerator\Tests` namespace to the `autoload-dev` section.