### PR TITLE
Fix issue #139 by adding an option to use another xsd-types.yml file

### DIFF
--- a/src/Command/GeneratePackageCommand.php
+++ b/src/Command/GeneratePackageCommand.php
@@ -89,6 +89,7 @@ class GeneratePackageCommand extends AbstractCommand
             ->addOption('enums-folder', null, InputOption::VALUE_OPTIONAL, 'Enumerations folder name (default: EnumType)')
             ->addOption('services-folder', null, InputOption::VALUE_OPTIONAL, 'Services class folder name (default: ServiceType)')
             ->addOption('src-dirname', null, InputOption::VALUE_OPTIONAL, 'Source directory subfolder oof destination directory (default: src)')
+            ->addOption('xsd-types-path', null, InputOption::VALUE_OPTIONAL, 'Path to the xsd types configuration file to load')
             ->addOption(self::GENERATOR_OPTIONS_CONFIG_OPTION, null, InputOption::VALUE_OPTIONAL, 'Path to the generator\'s configuration file to load');
     }
     /**
@@ -145,6 +146,7 @@ class GeneratePackageCommand extends AbstractCommand
             'suffix' => 'Suffix',
             'urlorpath' => 'Origin',
             'validation' => 'Validation',
+            'xsd-types-path' => 'XsdTypePath'
         ];
     }
     /**

--- a/src/Command/GeneratePackageCommand.php
+++ b/src/Command/GeneratePackageCommand.php
@@ -146,7 +146,7 @@ class GeneratePackageCommand extends AbstractCommand
             'suffix' => 'Suffix',
             'urlorpath' => 'Origin',
             'validation' => 'Validation',
-            'xsd-types-path' => 'XsdTypePath'
+            'xsd-types-path' => 'XsdTypesPath'
         ];
     }
     /**

--- a/src/ConfigurationReader/GeneratorOptions.php
+++ b/src/ConfigurationReader/GeneratorOptions.php
@@ -48,6 +48,7 @@ class GeneratorOptions extends AbstractYamlReader implements \JsonSerializable
     const VALIDATION = 'validation';
     const SCHEMAS_SAVE = 'schemas_save';
     const SCHEMAS_FOLDER = 'schemas_folder';
+    const XSD_TYPES_PATH = 'xsd_types_path';
     /**
      * Generator's options
      * @var array
@@ -723,6 +724,24 @@ class GeneratorOptions extends AbstractYamlReader implements \JsonSerializable
     public function setSchemasFolder($schemasFolder)
     {
         return $this->setOptionValue(self::SCHEMAS_FOLDER, $schemasFolder);
+    }
+    /**
+     * Get xsd type path option value
+     * @return string
+     */
+    public function getXsdTypesPath()
+    {
+        return $this->getOptionValue(self::XSD_TYPES_PATH);
+    }
+    /**
+     * Set xsd type path option value
+     * @throws \InvalidArgumentException
+     * @param string $xsdTypePath
+     * @return GeneratorOptions
+     */
+    public function setXsdTypePath($xsdTypePath)
+    {
+        return $this->setOptionValue(self::XSD_TYPES_PATH, $xsdTypePath);
     }
     /**
      * @return string[]

--- a/src/ConfigurationReader/GeneratorOptions.php
+++ b/src/ConfigurationReader/GeneratorOptions.php
@@ -726,7 +726,7 @@ class GeneratorOptions extends AbstractYamlReader implements \JsonSerializable
         return $this->setOptionValue(self::SCHEMAS_FOLDER, $schemasFolder);
     }
     /**
-     * Get xsd type path option value
+     * Get xsd types path option value
      * @return string
      */
     public function getXsdTypesPath()
@@ -734,14 +734,14 @@ class GeneratorOptions extends AbstractYamlReader implements \JsonSerializable
         return $this->getOptionValue(self::XSD_TYPES_PATH);
     }
     /**
-     * Set xsd type path option value
+     * Set xsd types path option value
      * @throws \InvalidArgumentException
-     * @param string $xsdTypePath
+     * @param string $xsdTypesPath
      * @return GeneratorOptions
      */
-    public function setXsdTypePath($xsdTypePath)
+    public function setXsdTypesPath($xsdTypesPath)
     {
-        return $this->setOptionValue(self::XSD_TYPES_PATH, $xsdTypePath);
+        return $this->setOptionValue(self::XSD_TYPES_PATH, $xsdTypesPath);
     }
     /**
      * @return string[]

--- a/src/File/AbstractModelFile.php
+++ b/src/File/AbstractModelFile.php
@@ -476,8 +476,8 @@ abstract class AbstractModelFile extends AbstractFile
     {
         $attribute = $this->getStructAttribute($attribute);
         $attributeType = $this->getStructAttributeType($attribute, true);
-        if (XsdTypes::instance()->isXsd($attributeType)) {
-            $attributeType = self::getPhpType($attributeType);
+        if (XsdTypes::instance($this->getGenerator()->getOptionXsdTypesPath())->isXsd($attributeType)) {
+            $attributeType = self::getPhpType($attributeType, $this->getGenerator()->getOptionXsdTypesPath());
         }
         return $attributeType;
     }
@@ -488,9 +488,9 @@ abstract class AbstractModelFile extends AbstractFile
      * @param mixed $fallback
      * @return mixed
      */
-    public static function getValidType($type, $fallback = null)
+    public static function getValidType($type, $xsdTypesPath = null, $fallback = null)
     {
-        return XsdTypes::instance()->isXsd(str_replace('[]', '', $type)) ? $fallback : $type;
+        return XsdTypes::instance($xsdTypesPath)->isXsd(str_replace('[]', '', $type)) ? $fallback : $type;
     }
     /**
      * See http://php.net/manual/fr/language.oop5.typehinting.php for these cases
@@ -499,8 +499,8 @@ abstract class AbstractModelFile extends AbstractFile
      * @param mixed $fallback
      * @return mixed
      */
-    public static function getPhpType($type, $fallback = self::TYPE_STRING)
+    public static function getPhpType($type, $xsdTypesPath = null, $fallback = self::TYPE_STRING)
     {
-        return XsdTypes::instance()->isXsd(str_replace('[]', '', $type)) ? XsdTypes::instance()->phpType($type) : $fallback;
+        return XsdTypes::instance($xsdTypesPath)->isXsd(str_replace('[]', '', $type)) ? XsdTypes::instance($xsdTypesPath)->phpType($type) : $fallback;
     }
 }

--- a/src/File/Service.php
+++ b/src/File/Service.php
@@ -164,7 +164,7 @@ class Service extends AbstractModelFile
                 $type = $model->getPackagedName(true);
             }
         }
-        return self::getValidType($type);
+        return self::getValidType($type, $this->getGenerator()->getOptionXsdTypesPath());
     }
     /**
      * @param string $soapHeaderName

--- a/src/File/Struct.php
+++ b/src/File/Struct.php
@@ -146,7 +146,7 @@ class Struct extends AbstractModelFile
      */
     protected function getStructMethodParameterType(StructAttributeModel $attribute, $returnArrayType = true)
     {
-        return self::getValidType($this->getStructAttributeTypeHint($attribute, $returnArrayType), null);
+        return self::getValidType($this->getStructAttributeTypeHint($attribute, $returnArrayType), $this->getGenerator()->getOptionXsdTypesPath(), null);
     }
     /**
      * @param MethodContainer $methods

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -825,6 +825,24 @@ class Generator implements \JsonSerializable
         return $this;
     }
     /**
+     * Gets the optionXsdTypesPath value
+     * @return string
+     */
+    public function getOptionXsdTypesPath()
+    {
+        return $this->options->getXsdTypesPath();
+    }
+    /**
+     * Sets the optionXsdTypesPath value
+     * @param string $xsdTypesPath
+     * @return Generator
+     */
+    public function setOptionXsdTypesPath($xsdTypesPath)
+    {
+        $this->options->setXsdTypesPath($xsdTypesPath);
+        return $this;
+    }
+    /**
      * Gets the WSDL
      * @return Wsdl|null
      */

--- a/src/resources/config/generator_options.yml
+++ b/src/resources/config/generator_options.yml
@@ -95,3 +95,6 @@ schemas_save:
 schemas_folder:
     default: 'wsdl'
     values: ''
+xsd_types_path:
+    default: ''
+    values: ''

--- a/tests/ConfigurationReader/GeneratorOptionsTest.php
+++ b/tests/ConfigurationReader/GeneratorOptionsTest.php
@@ -684,6 +684,7 @@ class GeneratorOptionsTest extends TestCase
             'services_folder' => 'ServiceType',
             'schemas_save' => false,
             'schemas_folder' => 'wsdl',
+            'xsd_types_path' => '',
         ], self::optionsInstance()->toArray());
     }
     /**
@@ -723,6 +724,7 @@ class GeneratorOptionsTest extends TestCase
             'services_folder' => 'ServiceType',
             'schemas_save' => false,
             'schemas_folder' => 'wsdl',
+            'xsd_types_path' => '',
         ], self::optionsInstance()->jsonSerialize());
     }
 }

--- a/tests/Generator/GeneratorTest.php
+++ b/tests/Generator/GeneratorTest.php
@@ -540,19 +540,15 @@ class GeneratorTest extends TestCase
         /**
      *
      */
-    public function testSetOptionXsdTypesPath()
+    public function testOptionXsdTypesPath()
     {
         $instance = self::localInstance();
+
+        $this->assertEmpty($instance->getOptionXsdTypesPath());
+        
         $instance->setOptionXsdTypesPath('/some/path/file.yml');
 
         $this->assertSame('/some/path/file.yml', $instance->getOptionXsdTypesPath());
-    }
-    /**
-     *
-     */
-    public function testGetOptionXsdTypesPath()
-    {
-        $this->assertEmpty(self::localInstance()->getOptionXsdTypesPath());
     }
     /**
      *

--- a/tests/Generator/GeneratorTest.php
+++ b/tests/Generator/GeneratorTest.php
@@ -537,6 +537,23 @@ class GeneratorTest extends TestCase
 
         $this->assertSame('wsdl', $instance->getOptionSchemasFolder());
     }
+        /**
+     *
+     */
+    public function testSetOptionXsdTypesPath()
+    {
+        $instance = self::localInstance();
+        $instance->setOptionXsdTypesPath('/some/path/file.yml');
+
+        $this->assertSame('/some/path/file.yml', $instance->getOptionXsdTypesPath());
+    }
+    /**
+     *
+     */
+    public function testGetOptionXsdTypesPath()
+    {
+        $this->assertEmpty(self::localInstance()->getOptionXsdTypesPath());
+    }
     /**
      *
      */

--- a/tests/resources/generated/json_serialized.json
+++ b/tests/resources/generated/json_serialized.json
@@ -3311,6 +3311,7 @@
         "enums_folder": "EnumType",
         "services_folder": "ServiceType",
         "schemas_save": false,
-        "schemas_folder": "wsdl"
+        "schemas_folder": "wsdl",
+        "xsd_types_path": ""
     }
 }

--- a/tests/resources/generator_options.yml
+++ b/tests/resources/generator_options.yml
@@ -94,3 +94,6 @@ schemas_save:
 schemas_folder:
     default: 'wsdl'
     values: ''
+xsd_types_path:
+    default: ''
+    values: ''

--- a/wsdltophp.yml.dist
+++ b/wsdltophp.yml.dist
@@ -98,3 +98,6 @@ schemas_save:
 schemas_folder:
     default: 'wsdl'
     values: ''
+xsd_types_path:
+    default: ''
+    values: ''


### PR DESCRIPTION
I add an option `xsd-types-path` to be able to load a different xsd-types.yml file.
This pull request will fix the #139 .