### PR TITLE
Fix: No need to update composer itself twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ php:
     - 7.1
     - 7.2
 
-before_install:
-    - composer self-update
-
 install:
     - composer install
 


### PR DESCRIPTION
This PR

* [x] stops updating `composer` itself twice

💁‍♂️ See, for example,

* https://travis-ci.org/WsdlToPhp/PackageGenerator/jobs/408827252#L426
* https://travis-ci.org/WsdlToPhp/PackageGenerator/jobs/408827252#L439