### PR TITLE
Enhancement: Cache dependencies between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ php:
     - 7.1
     - 7.2
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_install:
     - composer self-update
 


### PR DESCRIPTION
This PR

* [x] caches dependencies as installed with `composer` between Travis CI builds

💁‍♂️ For reference, see https://docs.travis-ci.com/user/caching/#arbitrary-directories.