### PR TITLE
Fixed wrong type for gYearMonth and gMonthDay

### DIFF
--- a/src/resources/config/xsd_types.yml
+++ b/src/resources/config/xsd_types.yml
@@ -21,7 +21,7 @@ xsd_types:
     float: "float"
     gDay: "string"
     gMonth: "string"
-    gMonthDay: "int"
+    gMonthDay: "string"
     gYear: "string"
     gYearMonth: "string"
     hexBinary: "string"

--- a/src/resources/config/xsd_types.yml
+++ b/src/resources/config/xsd_types.yml
@@ -23,7 +23,7 @@ xsd_types:
     gMonth: "string"
     gMonthDay: "int"
     gYear: "string"
-    gYearMonth: "int"
+    gYearMonth: "string"
     hexBinary: "string"
     int: "int"
     integer: "int"

--- a/tests/resources/xsd_types.yml
+++ b/tests/resources/xsd_types.yml
@@ -21,7 +21,7 @@ xsd_types:
     float: "float"
     gDay: "string"
     gMonth: "string"
-    gMonthDay: "int"
+    gMonthDay: "string"
     gYear: "string"
     gYearMonth: "string"
     hexBinary: "string"

--- a/tests/resources/xsd_types.yml
+++ b/tests/resources/xsd_types.yml
@@ -23,7 +23,7 @@ xsd_types:
     gMonth: "string"
     gMonthDay: "int"
     gYear: "string"
-    gYearMonth: "int"
+    gYearMonth: "string"
     hexBinary: "string"
     int: "int"
     integer: "int"


### PR DESCRIPTION
This fix should fix  #292, all tests were successful. 

That gYearMonth must be string instead of a integer can be see here for example: https://www.w3.org/2002/ws/databinding/examples/6/09/GYearMonthAttribute/