### PR TITLE
Fixed a bug in composer.json when trying to override default options like required php version

### DIFF
--- a/src/File/Composer.php
+++ b/src/File/Composer.php
@@ -91,7 +91,7 @@ final class Composer extends AbstractFile
 
     protected function addComposerSettings(array &$content): Composer
     {
-        $content = array_merge_recursive($content, $this->getGenerator()->getOptionComposerSettings());
+        $content = array_replace_recursive($content, $this->getGenerator()->getOptionComposerSettings());
 
         return $this;
     }


### PR DESCRIPTION
The content for `composer.json` is created by combining the default and optional settings. Previously, when trying to override the default setting, the new and old values were stored in a new array, which broke the composer structure. This is the standard behavior of `array_merge_recursive()`. A better alternative is to use `array_replace_recursive()`. It works the same way when merging different keys, but replaces the values of the existing keys.