### PR TITLE
issue #324 - fix how composer settings are created in the `GeneratorOptions` class

### DIFF
--- a/src/ConfigurationReader/GeneratorOptions.php
+++ b/src/ConfigurationReader/GeneratorOptions.php
@@ -124,7 +124,6 @@ final class GeneratorOptions extends AbstractYamlReader implements \JsonSerializ
     public const XSD_TYPES_PATH = 'xsd_types_path';
 
     protected array $options = [];
-    private bool $calledSetComposerSettings = false;
 
     protected function __construct(string $filename)
     {
@@ -163,7 +162,7 @@ final class GeneratorOptions extends AbstractYamlReader implements \JsonSerializ
         return array_key_exists('value', $this->options[$optionName]) ? $this->options[$optionName]['value'] : $this->options[$optionName]['default'];
     }
 
-    public function setOptionValue(string $optionName, $optionValue, array $values = []): self
+    public function setOptionValue(string $optionName, $optionValue, array $values = [], bool $callCustomMethod = true): self
     {
         if (!array_key_exists($optionName, $this->options)) {
             $this->options[$optionName] = [
@@ -172,8 +171,7 @@ final class GeneratorOptions extends AbstractYamlReader implements \JsonSerializ
             ];
         } elseif (!empty($this->options[$optionName]['values']) && !in_array($optionValue, $this->options[$optionName]['values'], true)) {
             throw new \InvalidArgumentException(sprintf('Invalid value "%s" for option "%s", possible values: %s', $optionValue, $optionName, implode(', ', $this->options[$optionName]['values'])), __LINE__);
-        } elseif (self::COMPOSER_SETTINGS === $optionName && is_array($optionValue) && !$this->calledSetComposerSettings) {
-            $this->calledSetComposerSettings = true;
+        } elseif (self::COMPOSER_SETTINGS === $optionName && is_array($optionValue) && $callCustomMethod) {
             $this->setComposerSettings($optionValue);
         } else {
             $this->options[$optionName]['value'] = $optionValue;
@@ -236,7 +234,7 @@ final class GeneratorOptions extends AbstractYamlReader implements \JsonSerializ
             }
         }
 
-        return $this->setOptionValue(self::COMPOSER_SETTINGS, $settings);
+        return $this->setOptionValue(self::COMPOSER_SETTINGS, $settings, [], false);
     }
 
     public function toArray(): array

--- a/src/ConfigurationReader/GeneratorOptions.php
+++ b/src/ConfigurationReader/GeneratorOptions.php
@@ -172,6 +172,9 @@ final class GeneratorOptions extends AbstractYamlReader implements \JsonSerializ
             ];
         } elseif (!empty($this->options[$optionName]['values']) && !in_array($optionValue, $this->options[$optionName]['values'], true)) {
             throw new \InvalidArgumentException(sprintf('Invalid value "%s" for option "%s", possible values: %s', $optionValue, $optionName, implode(', ', $this->options[$optionName]['values'])), __LINE__);
+        } elseif (self::COMPOSER_SETTINGS === $optionName && is_array($optionValue) && !$this->calledSetComposerSettings) {
+            $this->calledSetComposerSettings = true;
+            $this->setComposerSettings($optionValue);
         } else {
             $this->options[$optionName]['value'] = $optionValue;
         }

--- a/src/ConfigurationReader/GeneratorOptions.php
+++ b/src/ConfigurationReader/GeneratorOptions.php
@@ -124,6 +124,7 @@ final class GeneratorOptions extends AbstractYamlReader implements \JsonSerializ
     public const XSD_TYPES_PATH = 'xsd_types_path';
 
     protected array $options = [];
+    private bool $calledSetComposerSettings = false;
 
     protected function __construct(string $filename)
     {

--- a/tests/ConfigurationReader/GeneratorOptionsTest.php
+++ b/tests/ConfigurationReader/GeneratorOptionsTest.php
@@ -545,6 +545,58 @@ final class GeneratorOptionsTest extends AbstractTestCase
         self::optionsInstance()->setGenerateTutorialFile('null');
     }
 
+    public function testSetOptionValueComposerSettingsDotNotation(): void
+    {
+        $newOptionKey = 'composer_settings';
+        $newOptionValue = [
+            'config.disable-tls:true',
+            'autoload.psr-4.WsdlToPhp/PackageGenerator:src',
+        ];
+        $expectedResult = [
+            'config' => ['disable-tls' => true],
+            'autoload' => ['psr-4' => ['WsdlToPhp/PackageGenerator' => 'src']],
+        ];
+
+        $instance = self::optionsInstance();
+        $instance->setOptionValue($newOptionKey, $newOptionValue);
+
+        $this->assertSame(
+            $expectedResult['config'],
+            $instance->getComposerSettings()['config']
+        );
+
+        $this->assertSame(
+            $expectedResult['autoload'],
+            $instance->getComposerSettings()['autoload']
+        );
+    }
+
+    public function testSetOptionValueComposerSettingsPhpArray(): void
+    {
+        $newOptionKey = 'composer_settings';
+        $newOptionValue = [
+            'config' => ['disable-tls' => true],
+            'autoload' => ['psr-4' => ['WsdlToPhp/PackageGenerator' => 'src']],
+        ];
+        $expectedResult = [
+            'config' => ['disable-tls' => true],
+            'autoload' => ['psr-4' => ['WsdlToPhp/PackageGenerator' => 'src']],
+        ];
+
+        $instance = self::optionsInstance();
+        $instance->setOptionValue($newOptionKey, $newOptionValue);
+
+        $this->assertSame(
+            $expectedResult['config'],
+            $instance->getComposerSettings()['config']
+        );
+
+        $this->assertSame(
+            $expectedResult['autoload'],
+            $instance->getComposerSettings()['autoload']
+        );
+    }
+
     public function testGetUnexistingOptionValue(): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/File/ComposerTest.php
+++ b/tests/File/ComposerTest.php
@@ -66,7 +66,7 @@ final class ComposerTest extends AbstractFile
         $this->assertSameFileContent('ValidBingComposerSettings', $composerFile, 'json');
     }
 
-    public function testBingWithSettingsAssertJson(): void
+    public function testBingWithSettingsAdditionalOptions(): void
     {
         $instance = self::getBingGeneratorInstance(true);
         $instance
@@ -74,7 +74,7 @@ final class ComposerTest extends AbstractFile
             ->setOptionComposerName('wsdltophp/bing')
             ->setOptionComposerSettings([
                 'config.disable-tls:true',
-                'autoload.psr-4.WsdlToPhp/PackageGenerator:src',
+                'require.wsdltophp/wssecurity:dev-master',
                 'config.sort-packages:true',
                 'require-dev.friendsofphp/php-cs-fixer:^3.0',
                 'require-dev.phpstan/phpstan:^2',
@@ -88,7 +88,7 @@ final class ComposerTest extends AbstractFile
             ->write()
         ;
 
-        $this->assertJson(json_encode($composerFile->getFileName()));
+        $this->assertSameFileContent('ValidBingComposerSettingsAdditionalOptions', $composerFile, 'json');
     }
 
     public function testBingWithEmptySrcDirname(): void

--- a/tests/File/ComposerTest.php
+++ b/tests/File/ComposerTest.php
@@ -73,13 +73,13 @@ final class ComposerTest extends AbstractFile
             ->setOptionPrefix('Api')
             ->setOptionComposerName('wsdltophp/bing')
             ->setOptionComposerSettings([
-                'config.disable-tls:true',
                 'require.wsdltophp/wssecurity:dev-master',
-                'config.sort-packages:true',
                 'require-dev.friendsofphp/php-cs-fixer:^3.0',
                 'require-dev.phpstan/phpstan:^2',
                 'require-dev.phpunit/phpunit:^9',
-                'require-dev.rector/rector:^2'
+                'require-dev.rector/rector:^2',
+                'config.disable-tls:true',
+                'config.sort-packages:true'
             ])
         ;
         $composerFile = new Composer($instance, 'composer');

--- a/tests/File/ComposerTest.php
+++ b/tests/File/ComposerTest.php
@@ -66,6 +66,31 @@ final class ComposerTest extends AbstractFile
         $this->assertSameFileContent('ValidBingComposerSettings', $composerFile, 'json');
     }
 
+    public function testBingWithSettingsAssertJson(): void
+    {
+        $instance = self::getBingGeneratorInstance(true);
+        $instance
+            ->setOptionPrefix('Api')
+            ->setOptionComposerName('wsdltophp/bing')
+            ->setOptionComposerSettings([
+                'config.disable-tls:true',
+                'autoload.psr-4.WsdlToPhp/PackageGenerator:src',
+                'config.sort-packages:true',
+                'require-dev.friendsofphp/php-cs-fixer:^3.0',
+                'require-dev.phpstan/phpstan:^2',
+                'require-dev.phpunit/phpunit:^9',
+                'require-dev.rector/rector:^2'
+            ])
+        ;
+        $composerFile = new Composer($instance, 'composer');
+        $composerFile
+            ->setRunComposerUpdate(false)
+            ->write()
+        ;
+
+        $this->assertJson(json_encode($composerFile->getFileName()));
+    }
+
     public function testBingWithEmptySrcDirname(): void
     {
         $instance = self::getBingGeneratorInstance(true);

--- a/tests/resources/generated/ValidBingComposerSettingsAdditionalOptions.json
+++ b/tests/resources/generated/ValidBingComposerSettingsAdditionalOptions.json
@@ -9,17 +9,17 @@
         "wsdltophp/packagebase": "~5.0",
         "wsdltophp/wssecurity": "dev-master"
     },
+    "autoload": {
+        "psr-4": {
+            "": "./src/"
+        }
+    },  
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "phpstan/phpstan": "^2",
         "phpunit/phpunit": "^9",
         "rector/rector": "^2"
     },
-    "autoload": {
-        "psr-4": {
-            "": "./src/"
-        }
-    },  
     "config": {
         "disable-tls": true,
         "sort-packages": true

--- a/tests/resources/generated/ValidBingComposerSettingsAdditionalOptions.json
+++ b/tests/resources/generated/ValidBingComposerSettingsAdditionalOptions.json
@@ -1,0 +1,27 @@
+{
+    "name": "wsdltophp/bing",
+    "description": "Package generated from __WSDL_URL__ using wsdltophp/packagegenerator",
+    "require": {
+        "php": ">=7.4",
+        "ext-dom": "*",
+        "ext-mbstring": "*",
+        "ext-soap": "*",
+        "wsdltophp/packagebase": "~5.0",
+        "wsdltophp/wssecurity": "dev-master"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "phpstan/phpstan": "^2",
+        "phpunit/phpunit": "^9",
+        "rector/rector": "^2"
+    },
+    "autoload": {
+        "psr-4": {
+            "": "./src/"
+        }
+    },  
+    "config": {
+        "disable-tls": true,
+        "sort-packages": true
+    }
+}

--- a/tests/resources/generated/ValidBingComposerSettingsAdditionalOptions.json
+++ b/tests/resources/generated/ValidBingComposerSettingsAdditionalOptions.json
@@ -13,7 +13,7 @@
         "psr-4": {
             "": "./src/"
         }
-    },  
+    },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "phpstan/phpstan": "^2",


### PR DESCRIPTION
The `GeneratorOptions::setOptionValue` method contains a new condtion to check if the current input contains composer settings, and internally calls `setComposerSettings` if so. The unit tests attempt to test the following possibilites:
1. Composer settings are sent via command line
2. Composer settings are sent via a PHP project script

This fixes issue #324 where, when adding composer settings via the command line, the composer.json file was written as this:

```
"0": "config.disable-tls:true",
"1": "autoload.psr-4.Custom\\SoapClient\\:./Custom/SoapClient/"
```

instead of this:

```
"autoload": {
    "psr-4": {
        "Custom\\SoapClient\\": "./Custom/SoapClient/"
    }
},
"config": {
  "disable-tls": true
}
```