### PR TITLE
issue #340: do not apply the choice's maxOccurs bound to the chosen element's items count

### DIFF
--- a/src/File/Validation/ChoiceMaxOccursRule.php
+++ b/src/File/Validation/ChoiceMaxOccursRule.php
@@ -2,10 +2,35 @@
 
 namespace WsdlToPhp\PackageGenerator\File\Validation;
 
+/**
+ * The choice's maxOccurs attribute bounds the number of times the choice group may repeat,
+ * not the number of times the chosen element may occur within the group. When the element
+ * itself may occur more than once (its own maxOccurs is greater than 1 or unbounded), the
+ * element's occurrences count is constrained by its own maxOccurs rule, and applying the
+ * choice's bound to the element's items count would wrongly reject valid contents.
+ *
+ * @see https://github.com/WsdlToPhp/PackageGenerator/issues/340
+ */
 class ChoiceMaxOccursRule extends MaxOccursRule
 {
     public function name(): string
     {
         return 'choiceMaxOccurs';
+    }
+
+    public function testConditions(string $parameterName, $value, bool $itemType = false): string
+    {
+        $elementMaxOccurs = $this->getAttribute()->getMetaValueFirstSet([
+            'maxOccurs',
+            'maxoccurs',
+            'MaxOccurs',
+            'Maxoccurs',
+        ], 1);
+
+        if ('unbounded' === $elementMaxOccurs || 1 < (int) $elementMaxOccurs) {
+            return '';
+        }
+
+        return parent::testConditions($parameterName, $value, $itemType);
     }
 }

--- a/src/File/Validation/MaxOccursRule.php
+++ b/src/File/Validation/MaxOccursRule.php
@@ -45,7 +45,7 @@ class MaxOccursRule extends AbstractMinMaxRule
      *
      * @param mixed $value
      */
-    final public function testConditions(string $parameterName, $value, bool $itemType = false): string
+    public function testConditions(string $parameterName, $value, bool $itemType = false): string
     {
         $test = '';
         if ($this->getAttribute()->isArray() && ((is_scalar($value) && 'unbounded' !== $value) || (is_array($value) && !in_array('unbounded', $value)))) {

--- a/tests/File/StructTest.php
+++ b/tests/File/StructTest.php
@@ -510,6 +510,27 @@ final class StructTest extends AbstractFile
         }
     }
 
+    /**
+     * The choice elements have their own maxOccurs="5", the choice's maxOccurs (1) must
+     * not be applied to the elements' items count.
+     *
+     * @see https://github.com/WsdlToPhp/PackageGenerator/issues/340
+     */
+    public function testStructItemsChoiceTypeFromUnitTests(): void
+    {
+        $generator = self::unitTestsInstance();
+        if (($model = $generator->getStructByName('ItemsChoiceType')) instanceof StructModel) {
+            $struct = new StructFile($generator, $model->getName());
+            $struct
+                ->setModel($model)
+                ->write()
+            ;
+            $this->assertSameFileContent('ValidUnitTestsStructItemsChoiceType', $struct);
+        } else {
+            $this->fail('Unable to find ItemsChoiceType struct for file generation');
+        }
+    }
+
     public function testWriteDeliveryDetails(): void
     {
         $generator = self::deliveryServiceInstance();

--- a/tests/File/Validation/AbstractRule.php
+++ b/tests/File/Validation/AbstractRule.php
@@ -103,6 +103,11 @@ abstract class AbstractRule extends AbstractTestCase
         return self::getClassInstance('orderContractInstance', 'AddressDelivery_Type', $reset);
     }
 
+    public static function getUnitTestsItemsChoiceTypeInstance(bool $reset = false)
+    {
+        return self::getClassInstance('unitTestsInstance', 'ItemsChoiceType', $reset);
+    }
+
     public static function getEwsWorkingPeriodInstance(bool $reset = false)
     {
         // required for validating enumeration values

--- a/tests/File/Validation/ChoiceMaxOccursRuleTest.php
+++ b/tests/File/Validation/ChoiceMaxOccursRuleTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WsdlToPhp\PackageGenerator\Tests\File\Validation;
+
+/**
+ * The ItemsChoiceType struct contains a choice (choiceMaxOccurs: 1) whose elements have
+ * their own maxOccurs: 5, so each property must accept up to 5 items even though the
+ * choice itself may only occur once.
+ *
+ * @see https://github.com/WsdlToPhp/PackageGenerator/issues/340
+ *
+ * @internal
+ * @coversDefaultClass
+ */
+final class ChoiceMaxOccursRuleTest extends AbstractRule
+{
+    /**
+     * The ItemIdentifier
+     * Meta information extracted from the WSDL
+     * - choice: ItemIdentifier | ItemName
+     * - choiceMaxOccurs: 1
+     * - choiceMinOccurs: 1
+     * - maxOccurs: 5
+     * - minOccurs: 1.
+     */
+    public function testSetItemIdentifierWithSeveralItemsMustPass(): void
+    {
+        $instance = self::getUnitTestsItemsChoiceTypeInstance(true);
+
+        $this->assertSame($instance, $instance->setItemIdentifier([1, 2, 3, 4, 5]));
+    }
+
+    /**
+     * The ItemIdentifier
+     * Meta information extracted from the WSDL
+     * - choice: ItemIdentifier | ItemName
+     * - choiceMaxOccurs: 1
+     * - choiceMinOccurs: 1
+     * - maxOccurs: 5
+     * - minOccurs: 1.
+     */
+    public function testAddToItemIdentifierWithSeveralItemsMustPass(): void
+    {
+        $instance = self::getUnitTestsItemsChoiceTypeInstance(true);
+
+        $this->assertSame($instance, $instance->setItemIdentifier([1])->addToItemIdentifier(2)->addToItemIdentifier(3));
+    }
+
+    /**
+     * The ItemIdentifier
+     * Meta information extracted from the WSDL
+     * - choice: ItemIdentifier | ItemName
+     * - choiceMaxOccurs: 1
+     * - choiceMinOccurs: 1
+     * - maxOccurs: 5
+     * - minOccurs: 1.
+     */
+    public function testSetItemIdentifierWithTooManyItemsMustThrowAnException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid count of 6, the number of elements contained by the property must be less than or equal to 5');
+
+        $instance = self::getUnitTestsItemsChoiceTypeInstance(true);
+
+        $instance->setItemIdentifier([1, 2, 3, 4, 5, 6]);
+    }
+
+    /**
+     * The ItemName
+     * Meta information extracted from the WSDL
+     * - choice: ItemIdentifier | ItemName
+     * - choiceMaxOccurs: 1
+     * - choiceMinOccurs: 1
+     * - maxOccurs: 5
+     * - minOccurs: 1.
+     */
+    public function testSetItemNameAfterItemIdentifierMustThrowAnException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The property ItemName can\'t be set as the property ItemIdentifier is already set. Only one property must be set among these properties: ItemName, ItemIdentifier.');
+
+        $instance = self::getUnitTestsItemsChoiceTypeInstance(true);
+
+        $instance
+            ->setItemIdentifier([1, 2])
+            ->setItemName(['one', 'two'])
+        ;
+    }
+}

--- a/tests/resources/generated/ValidUnitTestsStructItemsChoiceType.php
+++ b/tests/resources/generated/ValidUnitTestsStructItemsChoiceType.php
@@ -1,0 +1,350 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StructType;
+
+use InvalidArgumentException;
+use WsdlToPhp\PackageBase\AbstractStructBase;
+
+/**
+ * This class stands for ItemsChoiceType StructType
+ * @package Api
+ * @subpackage Structs
+ * @release 1.1.0
+ */
+#[\AllowDynamicProperties]
+class ApiItemsChoiceType extends AbstractStructBase
+{
+    /**
+     * The ItemIdentifier
+     * Meta information extracted from the WSDL
+     * - choice: ItemIdentifier | ItemName
+     * - choiceMaxOccurs: 1
+     * - choiceMinOccurs: 1
+     * - maxOccurs: 5
+     * - minOccurs: 1
+     * - ref: tns:ItemIdentifier
+     * @var int[]
+     */
+    protected array $ItemIdentifier;
+    /**
+     * The ItemName
+     * Meta information extracted from the WSDL
+     * - choice: ItemIdentifier | ItemName
+     * - choiceMaxOccurs: 1
+     * - choiceMinOccurs: 1
+     * - maxOccurs: 5
+     * - minOccurs: 1
+     * - ref: tns:ItemName
+     * @var string[]
+     */
+    protected array $ItemName;
+    /**
+     * Constructor method for ItemsChoiceType
+     * @uses ApiItemsChoiceType::setItemIdentifier()
+     * @uses ApiItemsChoiceType::setItemName()
+     * @param int[] $itemIdentifier
+     * @param string[] $itemName
+     */
+    public function __construct(?array $itemIdentifier = null, ?array $itemName = null)
+    {
+        $this
+            ->setItemIdentifier($itemIdentifier)
+            ->setItemName($itemName);
+    }
+    /**
+     * Get ItemIdentifier value
+     * @return int[]|null
+     */
+    public function getItemIdentifier(): ?array
+    {
+        return $this->ItemIdentifier ?? null;
+    }
+    /**
+     * This method is responsible for validating the value(s) passed to the setItemIdentifier method
+     * This method is willingly generated in order to preserve the one-line inline validation within the setItemIdentifier method
+     * This has to validate that each item contained by the array match the itemType constraint
+     * @param array $values
+     * @return string A non-empty message if the values does not match the validation rules
+     */
+    public static function validateItemIdentifierForArrayConstraintFromSetItemIdentifier(?array $values = []): string
+    {
+        if (!is_array($values)) {
+            return '';
+        }
+        $message = '';
+        $invalidValues = [];
+        foreach ($values as $itemsChoiceTypeItemIdentifierItem) {
+            // validation for constraint: itemType
+            if (!(is_int($itemsChoiceTypeItemIdentifierItem) || ctype_digit($itemsChoiceTypeItemIdentifierItem))) {
+                $invalidValues[] = is_object($itemsChoiceTypeItemIdentifierItem) ? get_class($itemsChoiceTypeItemIdentifierItem) : sprintf('%s(%s)', gettype($itemsChoiceTypeItemIdentifierItem), var_export($itemsChoiceTypeItemIdentifierItem, true));
+            }
+        }
+        if (!empty($invalidValues)) {
+            $message = sprintf('The ItemIdentifier property can only contain items of type int, %s given', is_object($invalidValues) ? get_class($invalidValues) : (is_array($invalidValues) ? implode(', ', $invalidValues) : gettype($invalidValues)));
+        }
+        unset($invalidValues);
+        
+        return $message;
+    }
+    /**
+     * This method is responsible for validating the value(s) passed to the setItemIdentifier method
+     * This method is willingly generated in order to preserve the one-line inline validation within the setItemIdentifier method
+     * This has to validate that the property which is being set is the only one among the given choices
+     * @param mixed $value
+     * @return string A non-empty message if the values does not match the validation rules
+     */
+    public function validateItemIdentifierForChoiceConstraintFromSetItemIdentifier($value): string
+    {
+        $message = '';
+        if (is_null($value)) {
+            return $message;
+        }
+        $properties = [
+            'ItemName',
+        ];
+        try {
+            foreach ($properties as $property) {
+                if (isset($this->{$property})) {
+                    throw new InvalidArgumentException(sprintf('The property ItemIdentifier can\'t be set as the property %s is already set. Only one property must be set among these properties: ItemIdentifier, %s.', $property, implode(', ', $properties)), __LINE__);
+                }
+            }
+        } catch (InvalidArgumentException $e) {
+            $message = $e->getMessage();
+        }
+        
+        return $message;
+    }
+    /**
+     * Set ItemIdentifier value
+     * This property belongs to a choice that allows only one property to exist. It is
+     * therefore removable from the request, consequently if the value assigned to this
+     * property is null, the property is removed from this object
+     * @throws InvalidArgumentException
+     * @throws InvalidArgumentException
+     * @param int[] $itemIdentifier
+     * @return \StructType\ApiItemsChoiceType
+     */
+    public function setItemIdentifier(?array $itemIdentifier = null): self
+    {
+        // validation for constraint: array
+        if ('' !== ($itemIdentifierArrayErrorMessage = self::validateItemIdentifierForArrayConstraintFromSetItemIdentifier($itemIdentifier))) {
+            throw new InvalidArgumentException($itemIdentifierArrayErrorMessage, __LINE__);
+        }
+        // validation for constraint: choice(ItemIdentifier, ItemName)
+        if ('' !== ($itemIdentifierChoiceErrorMessage = self::validateItemIdentifierForChoiceConstraintFromSetItemIdentifier($itemIdentifier))) {
+            throw new InvalidArgumentException($itemIdentifierChoiceErrorMessage, __LINE__);
+        }
+        // validation for constraint: maxOccurs(5)
+        if (is_array($itemIdentifier) && count($itemIdentifier) > 5) {
+            throw new InvalidArgumentException(sprintf('Invalid count of %s, the number of elements contained by the property must be less than or equal to 5', count($itemIdentifier)), __LINE__);
+        }
+        if (is_null($itemIdentifier) || (is_array($itemIdentifier) && empty($itemIdentifier))) {
+            unset($this->ItemIdentifier);
+        } else {
+            $this->ItemIdentifier = $itemIdentifier;
+        }
+        
+        return $this;
+    }
+    /**
+     * This method is responsible for validating the value(s) passed to the addToItemIdentifier method
+     * This method is willingly generated in order to preserve the one-line inline validation within the addToItemIdentifier method
+     * This has to validate that the property which is being set is the only one among the given choices
+     * @param mixed $value
+     * @return string A non-empty message if the values does not match the validation rules
+     */
+    public function validateItemForChoiceConstraintFromAddToItemIdentifier($value): string
+    {
+        $message = '';
+        if (is_null($value)) {
+            return $message;
+        }
+        $properties = [
+            'ItemName',
+        ];
+        try {
+            foreach ($properties as $property) {
+                if (isset($this->{$property})) {
+                    throw new InvalidArgumentException(sprintf('The property ItemIdentifier can\'t be set as the property %s is already set. Only one property must be set among these properties: ItemIdentifier, %s.', $property, implode(', ', $properties)), __LINE__);
+                }
+            }
+        } catch (InvalidArgumentException $e) {
+            $message = $e->getMessage();
+        }
+        
+        return $message;
+    }
+    /**
+     * Add item to ItemIdentifier value
+     * @throws InvalidArgumentException
+     * @param int $item
+     * @return \StructType\ApiItemsChoiceType
+     */
+    public function addToItemIdentifier(int $item): self
+    {
+        // validation for constraint: itemType
+        if (!(is_int($item) || ctype_digit($item))) {
+            throw new InvalidArgumentException(sprintf('The ItemIdentifier property can only contain items of type int, %s given', is_object($item) ? get_class($item) : (is_array($item) ? implode(', ', $item) : gettype($item))), __LINE__);
+        }
+        // validation for constraint: choice(ItemIdentifier, ItemName)
+        if ('' !== ($itemChoiceErrorMessage = self::validateItemForChoiceConstraintFromAddToItemIdentifier($item))) {
+            throw new InvalidArgumentException($itemChoiceErrorMessage, __LINE__);
+        }
+        // validation for constraint: maxOccurs(5)
+        if (is_array($this->ItemIdentifier) && count($this->ItemIdentifier) >= 5) {
+            throw new InvalidArgumentException(sprintf('You can\'t add anymore element to this property that already contains %s elements, the number of elements contained by the property must be less than or equal to 5', count($this->ItemIdentifier)), __LINE__);
+        }
+        $this->ItemIdentifier[] = $item;
+        
+        return $this;
+    }
+    /**
+     * Get ItemName value
+     * @return string[]|null
+     */
+    public function getItemName(): ?array
+    {
+        return $this->ItemName ?? null;
+    }
+    /**
+     * This method is responsible for validating the value(s) passed to the setItemName method
+     * This method is willingly generated in order to preserve the one-line inline validation within the setItemName method
+     * This has to validate that each item contained by the array match the itemType constraint
+     * @param array $values
+     * @return string A non-empty message if the values does not match the validation rules
+     */
+    public static function validateItemNameForArrayConstraintFromSetItemName(?array $values = []): string
+    {
+        if (!is_array($values)) {
+            return '';
+        }
+        $message = '';
+        $invalidValues = [];
+        foreach ($values as $itemsChoiceTypeItemNameItem) {
+            // validation for constraint: itemType
+            if (!is_string($itemsChoiceTypeItemNameItem)) {
+                $invalidValues[] = is_object($itemsChoiceTypeItemNameItem) ? get_class($itemsChoiceTypeItemNameItem) : sprintf('%s(%s)', gettype($itemsChoiceTypeItemNameItem), var_export($itemsChoiceTypeItemNameItem, true));
+            }
+        }
+        if (!empty($invalidValues)) {
+            $message = sprintf('The ItemName property can only contain items of type string, %s given', is_object($invalidValues) ? get_class($invalidValues) : (is_array($invalidValues) ? implode(', ', $invalidValues) : gettype($invalidValues)));
+        }
+        unset($invalidValues);
+        
+        return $message;
+    }
+    /**
+     * This method is responsible for validating the value(s) passed to the setItemName method
+     * This method is willingly generated in order to preserve the one-line inline validation within the setItemName method
+     * This has to validate that the property which is being set is the only one among the given choices
+     * @param mixed $value
+     * @return string A non-empty message if the values does not match the validation rules
+     */
+    public function validateItemNameForChoiceConstraintFromSetItemName($value): string
+    {
+        $message = '';
+        if (is_null($value)) {
+            return $message;
+        }
+        $properties = [
+            'ItemIdentifier',
+        ];
+        try {
+            foreach ($properties as $property) {
+                if (isset($this->{$property})) {
+                    throw new InvalidArgumentException(sprintf('The property ItemName can\'t be set as the property %s is already set. Only one property must be set among these properties: ItemName, %s.', $property, implode(', ', $properties)), __LINE__);
+                }
+            }
+        } catch (InvalidArgumentException $e) {
+            $message = $e->getMessage();
+        }
+        
+        return $message;
+    }
+    /**
+     * Set ItemName value
+     * This property belongs to a choice that allows only one property to exist. It is
+     * therefore removable from the request, consequently if the value assigned to this
+     * property is null, the property is removed from this object
+     * @throws InvalidArgumentException
+     * @throws InvalidArgumentException
+     * @param string[] $itemName
+     * @return \StructType\ApiItemsChoiceType
+     */
+    public function setItemName(?array $itemName = null): self
+    {
+        // validation for constraint: array
+        if ('' !== ($itemNameArrayErrorMessage = self::validateItemNameForArrayConstraintFromSetItemName($itemName))) {
+            throw new InvalidArgumentException($itemNameArrayErrorMessage, __LINE__);
+        }
+        // validation for constraint: choice(ItemIdentifier, ItemName)
+        if ('' !== ($itemNameChoiceErrorMessage = self::validateItemNameForChoiceConstraintFromSetItemName($itemName))) {
+            throw new InvalidArgumentException($itemNameChoiceErrorMessage, __LINE__);
+        }
+        // validation for constraint: maxOccurs(5)
+        if (is_array($itemName) && count($itemName) > 5) {
+            throw new InvalidArgumentException(sprintf('Invalid count of %s, the number of elements contained by the property must be less than or equal to 5', count($itemName)), __LINE__);
+        }
+        if (is_null($itemName) || (is_array($itemName) && empty($itemName))) {
+            unset($this->ItemName);
+        } else {
+            $this->ItemName = $itemName;
+        }
+        
+        return $this;
+    }
+    /**
+     * This method is responsible for validating the value(s) passed to the addToItemName method
+     * This method is willingly generated in order to preserve the one-line inline validation within the addToItemName method
+     * This has to validate that the property which is being set is the only one among the given choices
+     * @param mixed $value
+     * @return string A non-empty message if the values does not match the validation rules
+     */
+    public function validateItemForChoiceConstraintFromAddToItemName($value): string
+    {
+        $message = '';
+        if (is_null($value)) {
+            return $message;
+        }
+        $properties = [
+            'ItemIdentifier',
+        ];
+        try {
+            foreach ($properties as $property) {
+                if (isset($this->{$property})) {
+                    throw new InvalidArgumentException(sprintf('The property ItemName can\'t be set as the property %s is already set. Only one property must be set among these properties: ItemName, %s.', $property, implode(', ', $properties)), __LINE__);
+                }
+            }
+        } catch (InvalidArgumentException $e) {
+            $message = $e->getMessage();
+        }
+        
+        return $message;
+    }
+    /**
+     * Add item to ItemName value
+     * @throws InvalidArgumentException
+     * @param string $item
+     * @return \StructType\ApiItemsChoiceType
+     */
+    public function addToItemName(string $item): self
+    {
+        // validation for constraint: itemType
+        if (!is_string($item)) {
+            throw new InvalidArgumentException(sprintf('The ItemName property can only contain items of type string, %s given', is_object($item) ? get_class($item) : (is_array($item) ? implode(', ', $item) : gettype($item))), __LINE__);
+        }
+        // validation for constraint: choice(ItemIdentifier, ItemName)
+        if ('' !== ($itemChoiceErrorMessage = self::validateItemForChoiceConstraintFromAddToItemName($item))) {
+            throw new InvalidArgumentException($itemChoiceErrorMessage, __LINE__);
+        }
+        // validation for constraint: maxOccurs(5)
+        if (is_array($this->ItemName) && count($this->ItemName) >= 5) {
+            throw new InvalidArgumentException(sprintf('You can\'t add anymore element to this property that already contains %s elements, the number of elements contained by the property must be less than or equal to 5', count($this->ItemName)), __LINE__);
+        }
+        $this->ItemName[] = $item;
+        
+        return $this;
+    }
+}

--- a/tests/resources/generated/parsed_unit_tests_none.json
+++ b/tests/resources/generated/parsed_unit_tests_none.json
@@ -283,6 +283,60 @@
                 },
                 "name": "UserType",
                 "__CLASS__": "WsdlToPhp\\PackageGenerator\\Model\\Struct"
+            },
+            {
+                "attributes": [
+                    {
+                        "containsElements": true,
+                        "removableFromRequest": false,
+                        "type": "int",
+                        "inheritance": "",
+                        "abstract": false,
+                        "meta": {
+                            "choice": [
+                                "ItemIdentifier",
+                                "ItemName"
+                            ],
+                            "choiceMaxOccurs": 1,
+                            "choiceMinOccurs": 1,
+                            "maxOccurs": "5",
+                            "minOccurs": "1",
+                            "ref": "tns:ItemIdentifier"
+                        },
+                        "name": "ItemIdentifier",
+                        "__CLASS__": "WsdlToPhp\\PackageGenerator\\Model\\StructAttribute"
+                    },
+                    {
+                        "containsElements": true,
+                        "removableFromRequest": false,
+                        "type": "string",
+                        "inheritance": "",
+                        "abstract": false,
+                        "meta": {
+                            "choice": [
+                                "ItemIdentifier",
+                                "ItemName"
+                            ],
+                            "choiceMaxOccurs": 1,
+                            "choiceMinOccurs": 1,
+                            "maxOccurs": "5",
+                            "minOccurs": "1",
+                            "ref": "tns:ItemName"
+                        },
+                        "name": "ItemName",
+                        "__CLASS__": "WsdlToPhp\\PackageGenerator\\Model\\StructAttribute"
+                    }
+                ],
+                "restriction": false,
+                "struct": true,
+                "types": [],
+                "values": [],
+                "list": "",
+                "inheritance": "",
+                "abstract": false,
+                "meta": [],
+                "name": "ItemsChoiceType",
+                "__CLASS__": "WsdlToPhp\\PackageGenerator\\Model\\Struct"
             }
         ]
     },

--- a/tests/resources/generated/parsed_unit_tests_start.json
+++ b/tests/resources/generated/parsed_unit_tests_start.json
@@ -283,6 +283,60 @@
                 },
                 "name": "UserType",
                 "__CLASS__": "WsdlToPhp\\PackageGenerator\\Model\\Struct"
+            },
+            {
+                "attributes": [
+                    {
+                        "containsElements": true,
+                        "removableFromRequest": false,
+                        "type": "int",
+                        "inheritance": "",
+                        "abstract": false,
+                        "meta": {
+                            "choice": [
+                                "ItemIdentifier",
+                                "ItemName"
+                            ],
+                            "choiceMaxOccurs": 1,
+                            "choiceMinOccurs": 1,
+                            "maxOccurs": "5",
+                            "minOccurs": "1",
+                            "ref": "tns:ItemIdentifier"
+                        },
+                        "name": "ItemIdentifier",
+                        "__CLASS__": "WsdlToPhp\\PackageGenerator\\Model\\StructAttribute"
+                    },
+                    {
+                        "containsElements": true,
+                        "removableFromRequest": false,
+                        "type": "string",
+                        "inheritance": "",
+                        "abstract": false,
+                        "meta": {
+                            "choice": [
+                                "ItemIdentifier",
+                                "ItemName"
+                            ],
+                            "choiceMaxOccurs": 1,
+                            "choiceMinOccurs": 1,
+                            "maxOccurs": "5",
+                            "minOccurs": "1",
+                            "ref": "tns:ItemName"
+                        },
+                        "name": "ItemName",
+                        "__CLASS__": "WsdlToPhp\\PackageGenerator\\Model\\StructAttribute"
+                    }
+                ],
+                "restriction": false,
+                "struct": true,
+                "types": [],
+                "values": [],
+                "list": "",
+                "inheritance": "",
+                "abstract": false,
+                "meta": [],
+                "name": "ItemsChoiceType",
+                "__CLASS__": "WsdlToPhp\\PackageGenerator\\Model\\Struct"
             }
         ]
     },

--- a/tests/resources/unit_tests.wsdl
+++ b/tests/resources/unit_tests.wsdl
@@ -62,6 +62,16 @@
                     <xsd:maxLength value="10"/>
                 </xsd:restriction>
             </xsd:simpleType>
+            <xsd:complexType name="ItemsChoiceType">
+                <xsd:sequence>
+                    <xsd:choice>
+                        <xsd:element ref="tns:ItemIdentifier" minOccurs="1" maxOccurs="5"/>
+                        <xsd:element ref="tns:ItemName" minOccurs="1" maxOccurs="5"/>
+                    </xsd:choice>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="ItemIdentifier" type="xsd:int"/>
+            <xsd:element name="ItemName" type="xsd:string"/>
         </xsd:schema>
         <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://schemas.xmlsoap.org/wsdl/">
             <xsd:element name="Error"></xsd:element>


### PR DESCRIPTION
Fixes #340

## Problem

When an element inside a `choice` defines its own `maxOccurs` greater than 1, the generated setter/adder wrongly applies the **choice's** `maxOccurs` (usually the default, 1) to the element's items count:

```xml
<complexType name="ItemsChoiceType">
    <sequence>
        <choice>
            <element ref="tns:ItemIdentifier" minOccurs="1" maxOccurs="5"/>
            <element ref="tns:ItemName" minOccurs="1" maxOccurs="5"/>
        </choice>
    </sequence>
</complexType>
```

generates:

```php
// validation for constraint: choiceMaxOccurs(1)
if (is_array($itemIdentifier) && count($itemIdentifier) > 1) {
    throw new InvalidArgumentException(...);
}
// validation for constraint: maxOccurs(5)
if (is_array($itemIdentifier) && count($itemIdentifier) > 5) {
    throw new InvalidArgumentException(...);
}
```

The first check makes the second unreachable: passing more than 1 item throws, even though the schema allows up to 5. Per XSD semantics, the choice's `maxOccurs` bounds how many times the choice **group** may repeat — not how many times the chosen element may occur within it; the element's occurrences are bounded by its **own** `maxOccurs`.

This is the same defect reported in #340 (there with `maxOccurs="unbounded"`). We hit it in production against Visa's VROL RTSI WSDL, whose `MarkBatchQueueItemAsReadRequestType` declares `<choice><element ref="vsi:BatchQueueItemSID" minOccurs="1" maxOccurs="5500"/>...</choice>` — the generated SDK rejects marking more than one queue item as read.

Note: the test added in #342 could not reproduce the issue because in `odigeo.wsdl` the `choice` itself carries `maxOccurs="unbounded"`, which `MaxOccursRule::testConditions()` already skips. The bug appears when the choice's `maxOccurs` is numeric (e.g. the default 1) while the child element's own `maxOccurs` is greater than 1 or unbounded.

## Fix

`ChoiceMaxOccursRule` now skips the items-count check when the element's own `maxOccurs` allows more than one occurrence — in that case the element's items count is already (and correctly) constrained by its own `maxOccurs` rule. When the element may occur at most once per group repetition, the behavior is unchanged: the choice's bound is applied as before, and the mutual-exclusion `choice` validation is untouched.

This required removing the `final` keyword from `MaxOccursRule::testConditions()` so the subclass can override it.

## Tests

- Added an `ItemsChoiceType` complex type to `tests/resources/unit_tests.wsdl` reproducing the shape above (element refs with `minOccurs="1" maxOccurs="5"` inside a default-occurrence choice) and regenerated `parsed_unit_tests_{none,start}.json` (additive only).
- `StructTest::testStructItemsChoiceTypeFromUnitTests` asserts the generated file contains the `maxOccurs(5)` check and no `choiceMaxOccurs(1)` items-count check.
- `ChoiceMaxOccursRuleTest` asserts at runtime that: several items pass (set and add), more than 5 items still throws (`maxOccurs`), and setting the other choice property still throws (choice constraint intact).

All new tests fail on `develop` without the `src` change. No other expected generated file changes: no existing fixture combines a numeric-`maxOccurs` choice with a multi-occurrence child.
